### PR TITLE
handle optionals during drift detection and updates for namespace

### DIFF
--- a/pulsar/resource_pulsar_namespace.go
+++ b/pulsar/resource_pulsar_namespace.go
@@ -364,7 +364,7 @@ func resourcePulsarNamespaceRead(d *schema.ResourceData, meta interface{}) error
 		}))
 	}
 
-	if persistencePoliciesConfig, ok := d.GetOk("persistence_policies"); ok && persistencePoliciesConfig.(*schema.Set).Len() > 0 {
+	if persPoliciesCfg, ok := d.GetOk("persistence_policies"); ok && persPoliciesCfg.(*schema.Set).Len() > 0 {
 		persistence, err := client.GetPersistence(ns.String())
 		if err != nil {
 			return fmt.Errorf("ERROR_READ_NAMESPACE: GetPersistence: %w", err)

--- a/pulsar/resource_pulsar_namespace_test.go
+++ b/pulsar/resource_pulsar_namespace_test.go
@@ -167,6 +167,7 @@ func TestNamespaceWithUndefinedOptionalsUpdate(t *testing.T) {
 	})
 }
 
+//nolint:unparam
 func testPulsarNamespaceExists(ns string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[ns]

--- a/pulsar/resource_pulsar_namespace_test.go
+++ b/pulsar/resource_pulsar_namespace_test.go
@@ -19,9 +19,10 @@ package pulsar
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/pulsar/resource_pulsar_tenant.go
+++ b/pulsar/resource_pulsar_tenant.go
@@ -19,6 +19,7 @@ package pulsar
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/pulsar/resource_pulsar_tenant.go
+++ b/pulsar/resource_pulsar_tenant.go
@@ -19,7 +19,6 @@ package pulsar
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -41,7 +40,7 @@ func resourcePulsarTenant() *schema.Resource {
 				Description: descriptions["tenant"],
 			},
 			"allowed_clusters": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: descriptions["allowed_clusters"],
 				Elem:        &schema.Schema{Type: schema.TypeString},
@@ -61,7 +60,7 @@ func resourcePulsarTenantCreate(d *schema.ResourceData, meta interface{}) error 
 
 	tenant := d.Get("tenant").(string)
 	adminRoles := handleHCLArray(d, "admin_roles")
-	allowedClusters := handleHCLArray(d, "allowed_clusters")
+	allowedClusters := handleHCLArrayV2(d.Get("allowed_clusters").(*schema.Set).List())
 
 	input := utils.TenantData{
 		Name:            tenant,
@@ -86,10 +85,6 @@ func resourcePulsarTenantRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("ERROR_READ_TENANT: %w", err)
 	}
 
-	// pulsar sometimes returns it in random order
-	sort.Strings(td.AdminRoles)
-	sort.Strings(td.AllowedClusters)
-
 	_ = d.Set("tenant", tenant)
 	_ = d.Set("admin_roles", td.AdminRoles)
 	_ = d.Set("allowed_clusters", td.AllowedClusters)
@@ -104,7 +99,7 @@ func resourcePulsarTenantUpdate(d *schema.ResourceData, meta interface{}) error 
 	d.Partial(true)
 	tenant := d.Get("tenant").(string)
 	adminRoles := handleHCLArray(d, "admin_roles")
-	allowedClusters := handleHCLArray(d, "allowed_clusters")
+	allowedClusters := handleHCLArrayV2(d.Get("allowed_clusters").(*schema.Set).List())
 
 	input := utils.TenantData{
 		Name:            tenant,

--- a/pulsar/resource_pulsar_tenant.go
+++ b/pulsar/resource_pulsar_tenant.go
@@ -85,6 +85,10 @@ func resourcePulsarTenantRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("ERROR_READ_TENANT: %w", err)
 	}
 
+	// pulsar sometimes returns it in random order
+	sort.Strings(td.AdminRoles)
+	sort.Strings(td.AllowedClusters)
+
 	_ = d.Set("tenant", tenant)
 	_ = d.Set("admin_roles", td.AdminRoles)
 	_ = d.Set("allowed_clusters", td.AllowedClusters)
@@ -163,17 +167,7 @@ func deleteExistingNamespacesForTenant(tenant string, meta interface{}) error {
 
 func handleHCLArray(d *schema.ResourceData, key string) []string {
 	hclArray := d.Get(key).([]interface{})
-	out := make([]string, 0)
-
-	if len(hclArray) == 0 {
-		return out
-	}
-
-	for _, value := range hclArray {
-		out = append(out, value.(string))
-	}
-
-	return out
+	return handleHCLArrayV2(hclArray)
 }
 
 func handleHCLArrayV2(hclArray []interface{}) []string {


### PR DESCRIPTION
Since pulsar have some defaults, it's quite beneficial to allow
undefined values in the tf definition.
That basically means "not managed by tf". But in the previous state
of this provider null-values were submitted in any case,
sometimes silently having breaking a valid setup or just facing a validation on
the pulsar side and failing an update.

This PR brings per-prop check, to avoid unnecessary api calls and be more precise on what is really updating.
That way if any of the optionals left empty, it wouldn't be changed on the pulsar side.

To mitigate some tf limitations, where tf doesn't know if props of an element of the set defined,
this PR brings some validation and assuming defaults which are invalid,
to simply ignore it later on update/create.

This leads to side effect of never empty plan after update when only part of the `namespace_config` specified.
![image](https://user-images.githubusercontent.com/1964214/79321714-0d6ffe80-7f0c-11ea-93fb-b0f422eb94ab.png)

That should encourage user to define all the properties. Another option would be to flatten this config and
use tf capabilities to check if its defined, but that would require migration of the state and config.

fixes #11