### PR TITLE
Add TLS options for custom trusted certs and insecure connections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ provider "pulsar" {
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------------- | ---------- |
 | `web_service_url`             | URL of your Apache Pulsar Cluster                             | `Yes` |
 | `token`           | Authentication Token for your Apache Pulsar Cluster, which is required only if your cluster has authentication enabled| `No`       |
+| `tls_trust_certs_file_path` | Path to a custom trusted TLS certificate file | `No`       |
+| `tls_allow_insecure_connection` | Boolean flag to accept untrusted TLS certificates | `No`       |
 
 Resources
 ------------

--- a/pulsar/provider.go
+++ b/pulsar/provider.go
@@ -147,8 +147,9 @@ var descriptions map[string]string
 
 func init() {
 	descriptions = map[string]string{
-		"web_service_url":               "Web service url is used to connect to your apache pulsar cluster",
-		"token":                         "Authentication Token used to grant terraform permissions to modify Apace Pulsar Entities",
+		"web_service_url": "Web service url is used to connect to your apache pulsar cluster",
+		"token": `Authentication Token used to grant terraform permissions
+to modify Apace Pulsar Entities`,
 		"api_version":                   "Api Version to be used for the pulsar admin interaction",
 		"tls_trust_certs_file_path":     "Path to a custom trusted TLS certificate file",
 		"tls_allow_insecure_connection": "Boolean flag to accept untrusted TLS certificates",

--- a/pulsar/provider.go
+++ b/pulsar/provider.go
@@ -51,6 +51,18 @@ func Provider() terraform.ResourceProvider {
 				Default:     "1",
 				Description: descriptions["api_version"],
 			},
+			"tls_trust_certs_file_path": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["tls_trust_certs_file_path"],
+				DefaultFunc: schema.EnvDefaultFunc("TLS_TRUST_CERTS_FILE_PATH", nil),
+			},
+			"tls_allow_insecure_connection": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: descriptions["tls_allow_insecure_connection"],
+				DefaultFunc: schema.EnvDefaultFunc("TLS_ALLOW_INSECURE_CONNECTION", false),
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"pulsar_tenant":    resourcePulsarTenant(),
@@ -85,6 +97,8 @@ func providerConfigure(d *schema.ResourceData, tfVersion string) (interface{}, e
 	clusterURL := d.Get("web_service_url").(string)
 	token := d.Get("token").(string)
 	pulsarAPIVersion := d.Get("api_version").(string)
+	TLSTrustCertsFilePath := d.Get("tls_trust_certs_file_path").(string)
+	TLSAllowInsecureConnection := d.Get("tls_allow_insecure_connection").(bool)
 
 	apiVersion, err := strconv.Atoi(pulsarAPIVersion)
 	if err != nil {
@@ -92,9 +106,11 @@ func providerConfigure(d *schema.ResourceData, tfVersion string) (interface{}, e
 	}
 
 	config := &common.Config{
-		WebServiceURL:    clusterURL,
-		Token:            token,
-		PulsarAPIVersion: common.APIVersion(apiVersion),
+		WebServiceURL:              clusterURL,
+		Token:                      token,
+		PulsarAPIVersion:           common.APIVersion(apiVersion),
+		TLSTrustCertsFilePath:      TLSTrustCertsFilePath,
+		TLSAllowInsecureConnection: TLSAllowInsecureConnection,
 	}
 
 	return pulsar.New(config)
@@ -131,12 +147,14 @@ var descriptions map[string]string
 
 func init() {
 	descriptions = map[string]string{
-		"web_service_url":  "Web service url is used to connect to your apache pulsar cluster",
-		"token":            "Authentication Token used to grant terraform permissions to modify Apace Pulsar Entities",
-		"api_version":      "Api Version to be used for the pulsar admin interaction",
-		"admin_roles":      "Admin roles to be attached to tenant",
-		"allowed_clusters": "Tenant will be able to interact with these clusters",
-		"namespace":        "Pulsar namespaces are logical groupings of topics",
+		"web_service_url":               "Web service url is used to connect to your apache pulsar cluster",
+		"token":                         "Authentication Token used to grant terraform permissions to modify Apace Pulsar Entities",
+		"api_version":                   "Api Version to be used for the pulsar admin interaction",
+		"tls_trust_certs_file_path":     "Path to a custom trusted TLS certificate file",
+		"tls_allow_insecure_connection": "Boolean flag to accept untrusted TLS certificates",
+		"admin_roles":                   "Admin roles to be attached to tenant",
+		"allowed_clusters":              "Tenant will be able to interact with these clusters",
+		"namespace":                     "Pulsar namespaces are logical groupings of topics",
 		"tenant": `An administrative unit for allocating capacity and enforcing an 
 authentication/authorization scheme`,
 		"namespace_list": "List of namespaces for a given tenant",


### PR DESCRIPTION
## Motivation
I would love to be able to use this provider but the cert on our endpoint is self-signed and as such I encountered the following error:
```
Error: ERROR_READ_TENANT: Get "https://[REDACTED]/admin/v2/tenants/public": x509: certificate signed by unknown authority
```
Adding it to the host system is possible but cumbersome for some use-cases (particularity when working with multiple clusters in a CI/CD environment.) Since this functionality is already available in the upstream package (and supported by existing pulsar clients) seemed like a good idea to add it to the provider.

## Modifications
* Adds `tls_trust_certs_file_path` to enable provider usage with custom certs (ie self-signed certs) and to better align provider config options with pulsar client config options.
* Adds `tls_allow_insecure_connection` to enable provider usage with custom certs _during development_.
