### PR TITLE
Adds backlog quota to namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ resource "pulsar_namespace" "test" {
     retention_minutes    = "1600"
     retention_size_in_mb = "10000"
   }  
+
+  backlog_quota {
+    limit_bytes  = "10000000000"
+    policy = "consumer_backlog_eviction"
+  }
   
   persistence_policies {
     bookkeeper_ensemble                   = 1   // Number of bookies to use for a topic, default: 0
@@ -227,6 +232,7 @@ resource "pulsar_namespace" "test" {
 | `namespace_config`            | Configuration for your namespaces like max allowed producers to produce messages | No |
 | `dispatch_rate`               | Apache Pulsar throttling config                                   | No |
 | `retention_policies`          | Data retention policies                                           | No |
+| `backlog_quota`               | [Backlog Quota](https://pulsar.apache.org/docs/en/admin-api-namespaces/#set-backlog-quota-policies) for all topics | No |
 | `persistence_policies`        | [Persistence policies](https://pulsar.apache.org/docs/en/admin-api-namespaces/#set-persistence-policies) for all topics under a given namespace       | No |
 
 ### `pulsar_topic`

--- a/examples/namespaces/main.tf
+++ b/examples/namespaces/main.tf
@@ -67,4 +67,9 @@ resource "pulsar_namespace" "test" {
     retention_minutes    = "1600"
     retention_size_in_mb = "10000"
   }
+
+  backlog_quota {
+    limit_bytes  = "10000000000"
+    policy = "producer_request_hold"
+  }
 }

--- a/pulsar/resource_pulsar_namespace.go
+++ b/pulsar/resource_pulsar_namespace.go
@@ -416,10 +416,8 @@ func resourcePulsarNamespaceUpdate(d *schema.ResourceData, meta interface{}) err
 		backlogQuota, err := unmarshalBacklogQuota(backlogQuotaConfig)
 		if err != nil {
 			errs = multierror.Append(errs, fmt.Errorf("unmarshalBacklogQuota: %w", err))
-		} else {
-			if err = client.SetBacklogQuota(nsName.String(), *backlogQuota); err != nil {
-				errs = multierror.Append(errs, fmt.Errorf("SetBacklogQuota: %w", err))
-			}
+		} else if err = client.SetBacklogQuota(nsName.String(), *backlogQuota); err != nil {
+			errs = multierror.Append(errs, fmt.Errorf("SetBacklogQuota: %w", err))
 		}
 	}
 

--- a/pulsar/resource_pulsar_namespace_test.go
+++ b/pulsar/resource_pulsar_namespace_test.go
@@ -247,8 +247,8 @@ func testNamespaceImported() resource.ImportStateCheckFunc {
 			return fmt.Errorf("expected %d states, got %d: %#v", 1, len(s), s)
 		}
 
-		if len(s[0].Attributes) != 7 {
-			return fmt.Errorf("expected %d attrs, got %d: %#v", 7, len(s[0].Attributes), s[0].Attributes)
+		if len(s[0].Attributes) != 8 {
+			return fmt.Errorf("expected %d attrs, got %d: %#v", 8, len(s[0].Attributes), s[0].Attributes)
 		}
 
 		return nil

--- a/pulsar/resource_pulsar_namespace_test.go
+++ b/pulsar/resource_pulsar_namespace_test.go
@@ -149,6 +149,7 @@ func TestNamespaceWithUndefinedOptionalsUpdate(t *testing.T) {
 					testPulsarNamespaceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "dispatch_rate.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "retention_policies.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "backlog_quota.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "namespace_config.#", "0"),
 					resource.TestCheckNoResourceAttr(resourceName, "enable_deduplication"),
 				),
@@ -159,6 +160,7 @@ func TestNamespaceWithUndefinedOptionalsUpdate(t *testing.T) {
 					testPulsarNamespaceExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "dispatch_rate.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "retention_policies.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "backlog_quota.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "namespace_config.#", "1"),
 					resource.TestCheckNoResourceAttr(resourceName, "enable_deduplication"),
 				),
@@ -367,6 +369,10 @@ resource "pulsar_namespace" "test" {
     managed_ledger_max_mark_delete_rate   = 0.0
   }
 
+  backlog_quota {
+    limit_bytes  = "10000000000"
+    policy = "producer_request_hold"
+  }
 }
 `, wsURL, cluster, tenant, ns)
 }


### PR DESCRIPTION
# Motivation
My team has recently started using this provider but we are unable update the backlog quota limit/policy on namespaces we create. This feature aims to allow us to get closer to a complete _infrastructure-as-code_ deployment for our pulsar stack.

I'm happy to make adjustments if needed :)

# Usage Example
1) Adding `backlog_quota` to a namespace
```
resource "pulsar_namespace" "ingest" {
  ...
  backlog_quota {
    limit_bytes  = "10000000000"
    policy = "consumer_backlog_eviction"
  }
}
```

2) Successfully updates
<img width="296" alt="Screen Shot 2020-11-23 at 8 31 28 PM" src="https://user-images.githubusercontent.com/5345624/100049073-4be76900-2dcb-11eb-8749-61282fa28fbc.png">

3) Viewing change w/ pulsar-admin
<img width="563" alt="Screen Shot 2020-11-23 at 8 31 41 PM" src="https://user-images.githubusercontent.com/5345624/100049069-49850f00-2dcb-11eb-9862-4bb50a0b068a.png">

4) Viewing change w/ pulsar manager
<img width="770" alt="Screen Shot 2020-11-23 at 8 30 36 PM" src="https://user-images.githubusercontent.com/5345624/100049075-4c7fff80-2dcb-11eb-9b9a-bd7c7a1ad9e0.png">
