### PR TITLE
Fix dispatch_rate and retention_policies state key usage for namespace resource

### DIFF
--- a/pulsar/resource_pulsar_namespace.go
+++ b/pulsar/resource_pulsar_namespace.go
@@ -312,10 +312,10 @@ func resourcePulsarNamespaceRead(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("ERROR_READ_NAMESPACE: GetRetention: %w", err)
 		}
 
-		_ = d.Set("persistence_policies", schema.NewSet(retentionPoliciesToHash, []interface{}{
+		_ = d.Set("retention_policies", schema.NewSet(retentionPoliciesToHash, []interface{}{
 			map[string]interface{}{
-				"retention_minutes":    string(ret.RetentionTimeInMinutes),
-				"retention_size_in_mb": string(ret.RetentionSizeInMB),
+				"retention_minutes":    fmt.Sprint(ret.RetentionTimeInMinutes),
+				"retention_size_in_mb": fmt.Sprint(ret.RetentionSizeInMB),
 			},
 		}))
 	}
@@ -340,7 +340,7 @@ func resourcePulsarNamespaceRead(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("ERROR_READ_NAMESPACE: GetDispatchRate: %w", err)
 		}
 
-		_ = d.Set("persistence_policies", schema.NewSet(dispatchRateToHash, []interface{}{
+		_ = d.Set("dispatch_rate", schema.NewSet(dispatchRateToHash, []interface{}{
 			map[string]interface{}{
 				"dispatch_msg_throttling_rate":  dr.DispatchThrottlingRateInMsg,
 				"rate_period_seconds":           dr.RatePeriodInSecond,


### PR DESCRIPTION
I stumbled across these minor issues while working on https://github.com/streamnative/terraform-provider-pulsar/pull/23 / https://github.com/streamnative/terraform-provider-pulsar/issues/8

1. A few state keys were not being set correctly in the namespace resource
2. A fix for this warning:
    > conversion from int to string yields a string of one rune,
    > not a string of digits (did you mean fmt.Sprint(x)?)