### PR TITLE
Add namespace permission grants

### DIFF
--- a/.github/workflows/acctest.yaml
+++ b/.github/workflows/acctest.yaml
@@ -21,7 +21,7 @@ jobs:
           export PATH=$PATH:$(pwd)/bin
           wget https://releases.hashicorp.com/terraform/0.12.17/terraform_0.12.17_linux_amd64.zip
           unzip terraform_0.12.17_linux_amd64.zip && sudo mv terraform /usr/local/bin
-          docker run -d -p 6650:6650 -p 8080:8080 -v $PWD/data:/pulsar/data apachepulsar/pulsar:2.4.1 bin/pulsar standalone
+          docker run -d -p 6650:6650 -p 8080:8080 -v $PWD/data:/pulsar/data apachepulsar/pulsar:2.7.0 bin/pulsar standalone
           mkdir -p $HOME/.terraform.d/plugins/linux_amd64
           sleep 10
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Requirements
 Installation
 ------------
 
-* Clone this repository and cd into the directory 
-* Run `make build`, it will out a file named `terraform-provider-pulsar` 
-* Copy this `terraform-provider-pulsar` bin file to your [terraform plugin directory][third-party-plugins] 
+* Clone this repository and cd into the directory
+* Run `make build`, it will out a file named `terraform-provider-pulsar`
+* Copy this `terraform-provider-pulsar` bin file to your [terraform plugin directory][third-party-plugins]
 * Typically this plugin directory is `~/.terraform.d/plugins/`
 * On Linux based 64-bit devices, this directory can be `~/.terraform.d/plugins/linux_amd64`
 
@@ -206,18 +206,23 @@ resource "pulsar_namespace" "test" {
   retention_policies {
     retention_minutes    = "1600"
     retention_size_in_mb = "10000"
-  }  
+  }
 
   backlog_quota {
     limit_bytes  = "10000000000"
     policy = "consumer_backlog_eviction"
   }
-  
+
   persistence_policies {
     bookkeeper_ensemble                   = 1   // Number of bookies to use for a topic, default: 0
     bookkeeper_write_quorum               = 1   // How many writes to make of each entry, default: 0
     bookkeeper_ack_quorum                 = 1   // Number of acks (guaranteed copies) to wait for each entry, default: 0
     managed_ledger_max_mark_delete_rate   = 0.0 // Throttling rate of mark-delete operation (0 means no throttle), default: 0.0
+  }
+
+  permission_grant {
+    role    = "some-role"
+    actions = ["produce", "consume", "functions"]
   }
 }
 ```
@@ -234,6 +239,7 @@ resource "pulsar_namespace" "test" {
 | `retention_policies`          | Data retention policies                                           | No |
 | `backlog_quota`               | [Backlog Quota](https://pulsar.apache.org/docs/en/admin-api-namespaces/#set-backlog-quota-policies) for all topics | No |
 | `persistence_policies`        | [Persistence policies](https://pulsar.apache.org/docs/en/admin-api-namespaces/#set-persistence-policies) for all topics under a given namespace       | No |
+| `permission_grant`            | [Permission grants](https://pulsar.apache.org/docs/en/admin-api-permissions/) on a namespace. This block can be repeated for each grant you'd like to add | No |
 
 ### `pulsar_topic`
 

--- a/pulsar/resource_pulsar_tenant_test.go
+++ b/pulsar/resource_pulsar_tenant_test.go
@@ -173,7 +173,8 @@ provider "pulsar" {
 }
 
 resource "pulsar_tenant" "test" {
-  tenant = "thanos"
+	tenant = "thanos"
+	allowed_clusters = ["standalone"]
 }`, testWebServiceURL)
 )
 
@@ -184,7 +185,7 @@ provider "pulsar" {
 }
 
 resource "pulsar_tenant" "test" {
-	tenant = "%s"	
+	tenant = "%s"
 	allowed_clusters = ["something"]
 }
 `, url, tname)

--- a/pulsar/validate_helpers.go
+++ b/pulsar/validate_helpers.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/streamnative/pulsarctl/pkg/pulsar/common"
 	"github.com/streamnative/pulsarctl/pkg/pulsar/utils"
 )
 
@@ -38,6 +39,15 @@ func validateTopicType(val interface{}, key string) (warns []string, errs []erro
 	_, err := utils.ParseTopicDomain(v)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("%q must be a valid topic name (got: %s): %w", key, v, err))
+	}
+	return
+}
+
+func validateAuthAction(val interface{}, key string) (warns []string, errs []error) {
+	v := val.(string)
+	_, err := common.ParseAuthAction(v)
+	if err != nil {
+		errs = append(errs, fmt.Errorf("%q must be a valid auth action (got: %s): %w", key, v, err))
 	}
 	return
 }

--- a/types/types.go
+++ b/types/types.go
@@ -17,6 +17,8 @@
 
 package types
 
+import "github.com/streamnative/pulsarctl/pkg/pulsar/common"
+
 type (
 	// configurable features of the Pulsar Namespace Entity via Terraform
 	NamespaceConfig struct {
@@ -30,5 +32,10 @@ type (
 	SplitNS struct {
 		Bundle             string
 		UnloadSplitBundles bool
+	}
+
+	PermissionGrant struct {
+		Role    string
+		Actions []common.AuthAction
 	}
 )


### PR DESCRIPTION
Usage follows the description here: https://github.com/streamnative/terraform-provider-pulsar/issues/8

```
resource "pulsar_namespace" "test" {
  ...
  permission_grant {
    role = "my-consumer"
    actions = ["consume"]
  }
}
```

This PR also includes a few other misc changes to get the integration test suite passing - which I've pointed out in the GitHub comments below. That said, if there's a better way to go about those, please let me know and I'd be happy to make adjustments.

If we feel like this is all headed in the right direction, I can also work on an analogous PR for topic permission grants.