### PR TITLE
Add topic permission grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,11 @@ resource "pulsar_topic" "sample-topic-1" {
   topic_type = "persistent"
   topic_name = "partition-topic"
   partitions = 4                     # partitions > 0 means this is a partition topic
+
+  permission_grant {
+    role    = "some-role"
+    actions = ["produce", "consume", "functions"]
+  }
 }
 
 resource "pulsar_topic" "sample-topic-2" {
@@ -266,8 +271,24 @@ resource "pulsar_topic" "sample-topic-2" {
   topic_type = "persistent"
   topic_name = "non-partition-topic"
   partitions = 0                     # partitions = 0 means this is a non-partition topic
+
+  permission_grant {
+    role    = "some-role"
+    actions = ["produce", "consume", "functions"]
+  }
 }
 ```
+
+#### Properties
+
+| Property                      | Description                                                       | Required                   |
+| ----------------------------- | ----------------------------------------------------------------- |----------------------------|
+| `tenant`                      | Name of the Tenant managing this topic                            | Yes
+| `namespace`                   | Name of the Namespace for this topic                              | Yes
+| `topic_type`                  | Topic persistence (`persistent`, `non-persistent`)                | Yes
+| `topic_name`                  | Name of the topic                                                 | Yes
+| `partitions`                  | Number of [partitions](https://pulsar.apache.org/docs/en/concepts-messaging/#partitioned-topics) (`0` for non-partitioned topic, `> 1` for partitioned topic) | Yes
+| `permission_grant`            | [Permission grants](https://pulsar.apache.org/docs/en/admin-api-permissions/) on a topic. This block can be repeated for each grant you'd like to add. Permission grants are also inherited from the topic's namespace. | No |
 
 
 Importing existing resources

--- a/pulsar/permission_grant.go
+++ b/pulsar/permission_grant.go
@@ -1,0 +1,78 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package pulsar
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/streamnative/pulsarctl/pkg/pulsar/common"
+	"github.com/streamnative/terraform-provider-pulsar/types"
+)
+
+func permissionGrantToHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	buf.WriteString(fmt.Sprintf("%s-", m["role"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["actions"].([]string)))
+
+	return hashcode.String(buf.String())
+}
+
+func unmarshalPermissionGrants(v []interface{}) ([]*types.PermissionGrant, error) {
+	permissionGrants := make([]*types.PermissionGrant, 0, len(v))
+	for _, grant := range v {
+		data := grant.(map[string]interface{})
+
+		var permissionGrant types.PermissionGrant
+		permissionGrant.Role = data["role"].(string)
+
+		var actions []common.AuthAction
+		for _, action := range data["actions"].(*schema.Set).List() {
+			authAction, err := common.ParseAuthAction(action.(string))
+			if err != nil {
+				return nil, fmt.Errorf("ERROR_INVALID_AUTH_ACTION: %w", err)
+			}
+			actions = append(actions, authAction)
+		}
+		permissionGrant.Actions = actions
+
+		permissionGrants = append(permissionGrants, &permissionGrant)
+	}
+
+	return permissionGrants, nil
+}
+
+func setPermissionGrant(d *schema.ResourceData, grants map[string][]common.AuthAction) {
+	permissionGrants := []interface{}{}
+	for role, roleActions := range grants {
+		actions := []string{}
+		for _, action := range roleActions {
+			actions = append(actions, action.String())
+		}
+		permissionGrants = append(permissionGrants, map[string]interface{}{
+			"role":    role,
+			"actions": actions,
+		})
+	}
+
+	_ = d.Set("permission_grant", schema.NewSet(permissionGrantToHash, permissionGrants))
+}


### PR DESCRIPTION
Usage mirrors that of namespace permission grants

```
resource "pulsar_topic" "test" {
  ...
  permission_grant {
    role       = "some-role"
    actions = ["consume", "produce", "functions"]
  }
}
```

I've also tried to harmonize a few of the implementation details of
namespaces and topics with each other.