### PR TITLE
Prevent SetRetention call if no retention policy is set on topic

### DIFF
--- a/pulsar/resource_pulsar_topic.go
+++ b/pulsar/resource_pulsar_topic.go
@@ -380,11 +380,13 @@ func updateRetentionPolicies(d *schema.ResourceData, meta interface{}, topicName
 	}
 
 	var policies utils.RetentionPolicies
-	if retentionPoliciesConfig.Len() > 0 {
-		data := retentionPoliciesConfig.List()[0].(map[string]interface{})
-		policies.RetentionTimeInMinutes = data["retention_time_minutes"].(int)
-		policies.RetentionSizeInMB = int64(data["retention_size_mb"].(int))
+	if retentionPoliciesConfig.Len() < 1 {
+		return nil
 	}
+
+	data := retentionPoliciesConfig.List()[0].(map[string]interface{})
+	policies.RetentionTimeInMinutes = data["retention_time_minutes"].(int)
+	policies.RetentionSizeInMB = int64(data["retention_size_mb"].(int))
 
 	if err := client.SetRetention(*topicName, policies); err != nil {
 		return fmt.Errorf("ERROR_UPDATE_RETENTION_POLICIES: SetRetention: %w", err)

--- a/pulsar/resource_pulsar_topic.go
+++ b/pulsar/resource_pulsar_topic.go
@@ -379,17 +379,15 @@ func updateRetentionPolicies(d *schema.ResourceData, meta interface{}, topicName
 			"unsupported set retention policies for non-persistent topic")
 	}
 
-	var policies utils.RetentionPolicies
-	if retentionPoliciesConfig.Len() < 1 {
-		return nil
-	}
+	if retentionPoliciesConfig.Len() > 0 {
+		var policies utils.RetentionPolicies
+		data := retentionPoliciesConfig.List()[0].(map[string]interface{})
+		policies.RetentionTimeInMinutes = data["retention_time_minutes"].(int)
+		policies.RetentionSizeInMB = int64(data["retention_size_mb"].(int))
 
-	data := retentionPoliciesConfig.List()[0].(map[string]interface{})
-	policies.RetentionTimeInMinutes = data["retention_time_minutes"].(int)
-	policies.RetentionSizeInMB = int64(data["retention_size_mb"].(int))
-
-	if err := client.SetRetention(*topicName, policies); err != nil {
-		return fmt.Errorf("ERROR_UPDATE_RETENTION_POLICIES: SetRetention: %w", err)
+		if err := client.SetRetention(*topicName, policies); err != nil {
+			return fmt.Errorf("ERROR_UPDATE_RETENTION_POLICIES: SetRetention: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
The `SetRetention` Pulsar client's method is called also when retention policies are not set in the Terraform files. 
This leads to the following error when the topic level policies are not enabled on Pulsar (an example can be found [here](https://github.com/esenac/pulsar-terraform-examples/tree/prevent-set-topic-policies). 
```
Error: ERROR_CREATE_TOPIC_RETENTION_POLICIES: ERROR_UPDATE_RETENTION_POLICIES: SetRetention: code: 405 reason: Topic level policies is disabled, to enable the topic level policy and retry.
```
This PR addresses such behavior preventing the call to the SetRetention method when retention policies are not declared in Terraform.