### PR TITLE
fix: upgrade pulsarctl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/posener/complete v1.2.3 // indirect
-	github.com/streamnative/pulsarctl v0.4.3-0.20220124120652-ed7f74559899
+	github.com/streamnative/pulsarctl v0.4.3-0.20220429151807-09f449b33265
 	github.com/ulikunitz/xz v0.5.6 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/zclconf/go-cty v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,7 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
@@ -352,6 +353,8 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/streamnative/pulsarctl v0.4.3-0.20220124120652-ed7f74559899 h1:0CRLtisS+U/zFShwpZV3jCFy/6FlFXmM+Z08d8r9Csg=
 github.com/streamnative/pulsarctl v0.4.3-0.20220124120652-ed7f74559899/go.mod h1:wPNx0CzVy5fgRhTk4HymONYYaARSG4pVIDc4I6XujOU=
+github.com/streamnative/pulsarctl v0.4.3-0.20220429151807-09f449b33265 h1:KEDI2k8v1NbGw3qRj7icg9RQHVa078NVEQpGfV9a7RA=
+github.com/streamnative/pulsarctl v0.4.3-0.20220429151807-09f449b33265/go.mod h1:wPNx0CzVy5fgRhTk4HymONYYaARSG4pVIDc4I6XujOU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

The old pulsarctl cannot be compatible with the Pulsar 2.10, the http client has some bugs,  these bugs has been fixed by https://github.com/streamnative/pulsarctl/pull/662, https://github.com/streamnative/pulsarctl/pull/610

### Modifications

Upgrade the pulsarctl to latest version

### Documentation
- [x] `no-need-doc` 


