### PR TITLE
environment variable for key_file_path

### DIFF
--- a/pulsar/provider.go
+++ b/pulsar/provider.go
@@ -129,6 +129,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: descriptions["key_file_path"],
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"PULSAR_KEY_FILE", "PULSAR_KEY_FILE_PATH"}, ""),
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
### Motivation

I'd like to avoid storing secrets in git therefore I'd like to define the `private_key_file` in the `provider` block using an environment variable.

### Modifications

The change allows the environment variables `PULSAR_KEY_FILE` or `PULSAR_KEY_FILE_PATH` to define a private key using the following format:

```
data://{"type":"sn_service_account","client_id":"***","client_secret":"***","client_email":"john.doe@example.auth.streamnative.cloud","issuer_url":"https://auth.streamnative.cloud/"}
```

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 

I did not know where to document the change, I'm missing a documentation of environment variables in general.