### PR TITLE
fix: set subscription_position default value to string Earliest

### DIFF
--- a/pulsar/resource_pulsar_sink.go
+++ b/pulsar/resource_pulsar_sink.go
@@ -78,7 +78,7 @@ func init() {
 	resourceSinkDescriptions[resourceSinkCleanupSubscriptionKey] =
 		"Whether the subscriptions the functions created/used should be deleted when the functions was deleted"
 	resourceSinkDescriptions[resourceSinkSubscriptionPositionKey] =
-		"Pulsar source subscription position if user wants to consume messages from the specified location (Latest, Earliest)"
+		"Pulsar source subscription position if user wants to consume messages from the specified location (Latest, Earliest). Default to Earliest."
 	resourceSinkDescriptions[resourceSinkCustomSerdeInputsKey] =
 		"The map of input topics to SerDe class names (as a JSON string)"
 	resourceSinkDescriptions[resourceSinkCustomSchemaInputsKey] =
@@ -173,7 +173,7 @@ func resourcePulsarSink() *schema.Resource {
 			resourceSinkSubscriptionPositionKey: {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     utils.Earliest,
+				Default:     "Earliest",
 				Description: resourceSinkDescriptions[resourceSinkSubscriptionPositionKey],
 			},
 			resourceSinkCustomSerdeInputsKey: {

--- a/pulsar/resource_pulsar_sink.go
+++ b/pulsar/resource_pulsar_sink.go
@@ -77,8 +77,8 @@ func init() {
 		"Pulsar source subscription name if user wants a specific subscription-name for input-topic consumer"
 	resourceSinkDescriptions[resourceSinkCleanupSubscriptionKey] =
 		"Whether the subscriptions the functions created/used should be deleted when the functions was deleted"
-	resourceSinkDescriptions[resourceSinkSubscriptionPositionKey] =
-		"Pulsar source subscription position if user wants to consume messages from the specified location (Latest, Earliest). Default to Earliest."
+	resourceSinkDescriptions[resourceSinkSubscriptionPositionKey] = "Pulsar source subscription position if user wants " +
+		"to consume messages from the specified location (Latest, Earliest). Default to Earliest."
 	resourceSinkDescriptions[resourceSinkCustomSerdeInputsKey] =
 		"The map of input topics to SerDe class names (as a JSON string)"
 	resourceSinkDescriptions[resourceSinkCustomSchemaInputsKey] =


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #76 

### Motivation

The data type of subscription_position default value should be string.

### Modifications

- set subscription_position default value to string `Earliest`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

