### PR TITLE
force functions and connector using v3 api admin client

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,6 @@ A resource for creating and managing Apache Pulsar Functions.
 ```hcl
 provider "pulsar" {
   web_service_url = "http://localhost:8080"
-  api_version = "3"
 }
 
 resource "pulsar_function" "function-1" {
@@ -462,7 +461,6 @@ A resource for creating and managing Apache Pulsar Sources.
 ```hcl
 provider "pulsar" {
   web_service_url = "http://localhost:8080"
-  api_version = "3"
 }
 
 resource "pulsar_source" "source-1" {
@@ -514,7 +512,6 @@ A resource for creating and managing Apache Pulsar Sinks.
 ```hcl
 provider "pulsar" {
   web_service_url = "http://localhost:8080"
-  api_version = "3"
 }
 
 resource "pulsar_sink" "sample-sink-1" {

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ description: |-
 
 ### Optional
 
-- `api_version` (String) Api Version to be used for the pulsar admin interaction (DEPRECATED)
+- `api_version` (String) Api Version to be used for the pulsar admin interaction
 - `audience` (String) The OAuth 2.0 resource server identifier for the Pulsar cluster
 - `client_id` (String) The OAuth 2.0 client identifier
 - `issuer_url` (String) The OAuth 2.0 URL of the authentication provider which allows the Pulsar client to obtain an access token

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ description: |-
 
 ### Optional
 
-- `api_version` (String) Api Version to be used for the pulsar admin interaction
+- `api_version` (String) Api Version to be used for the pulsar admin interaction (DEPRECATED)
 - `audience` (String) The OAuth 2.0 resource server identifier for the Pulsar cluster
 - `client_id` (String) The OAuth 2.0 client identifier
 - `issuer_url` (String) The OAuth 2.0 URL of the authentication provider which allows the Pulsar client to obtain an access token

--- a/examples/functions/main.tf
+++ b/examples/functions/main.tf
@@ -26,7 +26,6 @@ terraform {
 
 provider "pulsar" {
   web_service_url = "http://localhost:8080"
-  api_version = "3"
 }
 
 // Note: function resource requires v3 api.

--- a/examples/sinks/main.tf
+++ b/examples/sinks/main.tf
@@ -26,7 +26,6 @@ terraform {
 
 provider "pulsar" {
   web_service_url = "http://localhost:8080"
-  api_version = "3"
 }
 
 // Note: sink resource requires v3 api.

--- a/examples/sources/main.tf
+++ b/examples/sources/main.tf
@@ -26,7 +26,6 @@ terraform {
 
 provider "pulsar" {
   web_service_url = "http://localhost:8080"
-  api_version = "3"
 }
 
 resource "pulsar_source" "source-1" {

--- a/pulsar/client.go
+++ b/pulsar/client.go
@@ -22,5 +22,9 @@ import (
 )
 
 func getClientFromMeta(meta interface{}) admin.Client {
-	return meta.(admin.Client)
+	return meta.(PulsarClientBundle).Client
+}
+
+func getV3ClientFromMeta(meta interface{}) admin.Client {
+	return meta.(PulsarClientBundle).V3Client
 }

--- a/pulsar/provider.go
+++ b/pulsar/provider.go
@@ -42,7 +42,7 @@ func init() {
 	descriptions = map[string]string{
 		"web_service_url":                "Web service url is used to connect to your apache pulsar cluster",
 		"token":                          "Authentication Token used to grant terraform permissions to modify Apace Pulsar Entities",
-		"api_version":                    "Api Version to be used for the pulsar admin interaction, DEPRECATED: no need to set this value",
+		"api_version":                    "Api Version to be used for the pulsar admin interaction",
 		"tls_trust_certs_file_path":      "Path to a custom trusted TLS certificate file",
 		"tls_key_file_path":              "Path to the key to use when using TLS client authentication",
 		"tls_cert_file_path":             "Path to the cert to use when using TLS client authentication",

--- a/pulsar/provider.go
+++ b/pulsar/provider.go
@@ -24,7 +24,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
+	pulsaradmin "github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin"
+	adminconfig "github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
@@ -41,7 +42,7 @@ func init() {
 	descriptions = map[string]string{
 		"web_service_url":                "Web service url is used to connect to your apache pulsar cluster",
 		"token":                          "Authentication Token used to grant terraform permissions to modify Apace Pulsar Entities",
-		"api_version":                    "Api Version to be used for the pulsar admin interaction",
+		"api_version":                    "Api Version to be used for the pulsar admin interaction, DEPRECATED: no need to set this value",
 		"tls_trust_certs_file_path":      "Path to a custom trusted TLS certificate file",
 		"tls_key_file_path":              "Path to the key to use when using TLS client authentication",
 		"tls_cert_file_path":             "Path to the cert to use when using TLS client authentication",
@@ -67,6 +68,12 @@ func init() {
 		"scope":                          "The OAuth 2.0 scope(s) to request",
 		"key_file_path":                  "The path of the private key file",
 	}
+}
+
+// PulsarClientBundle is a struct that holds the pulsar admin client for both v2 and v3 api versions
+type PulsarClientBundle struct {
+	Client   pulsaradmin.Client
+	V3Client pulsaradmin.Client
 }
 
 // Provider returns a schema.Provider
@@ -204,10 +211,17 @@ func providerConfigure(d *schema.ResourceData, tfVersion string) (interface{}, d
 		return nil, diag.FromErr(fmt.Errorf("ERROR_PULSAR_CONFIG_tls_TRUST_FILE_NOTEXIST: %q", TLSTrustCertsFilePath))
 	}
 
-	config := &config.Config{
+	configVersion := adminconfig.APIVersion(apiVersion)
+	// for backward compatibility, if user state api_version as 3
+	// we will use v2 as the default client version because we have v3 as individual client
+	if configVersion == adminconfig.V3 {
+		configVersion = adminconfig.APIVersion(0) // v2 will be the default client version
+	}
+
+	config := &adminconfig.Config{
 		WebServiceURL:              clusterURL,
 		Token:                      token,
-		PulsarAPIVersion:           config.APIVersion(apiVersion),
+		PulsarAPIVersion:           configVersion,
 		TLSTrustCertsFilePath:      TLSTrustCertsFilePath,
 		TLSAllowInsecureConnection: TLSAllowInsecureConnection,
 		IssuerEndpoint:             issuerEndpoint,
@@ -226,7 +240,34 @@ func providerConfigure(d *schema.ResourceData, tfVersion string) (interface{}, d
 		return nil, diag.FromErr(err)
 	}
 
-	return client, nil
+	configV3 := &adminconfig.Config{
+		WebServiceURL:              clusterURL,
+		Token:                      token,
+		PulsarAPIVersion:           adminconfig.V3,
+		TLSTrustCertsFilePath:      TLSTrustCertsFilePath,
+		TLSAllowInsecureConnection: TLSAllowInsecureConnection,
+		IssuerEndpoint:             issuerEndpoint,
+		ClientID:                   clientID,
+		Audience:                   audience,
+		Scope:                      scope,
+		KeyFile:                    keyFilePath,
+		TLSKeyFile:                 TLSKeyFilePath,
+		TLSCertFile:                TLSCertFilePath,
+	}
+
+	clientV3, err := admin.NewPulsarAdminClient(&admin.PulsarAdminConfig{
+		Config: configV3,
+	})
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+
+	clientBundle := PulsarClientBundle{
+		Client:   client,
+		V3Client: clientV3,
+	}
+
+	return clientBundle, nil
 }
 
 // Exists reports whether the named file or directory exists.

--- a/pulsar/resource_pulsar_function.go
+++ b/pulsar/resource_pulsar_function.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/rest"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -380,7 +379,7 @@ func resourcePulsarFunction() *schema.Resource {
 }
 
 func resourcePulsarFunctionRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(admin.Client).Functions()
+	client := getV3ClientFromMeta(meta).Functions()
 
 	tenant := d.Get(resourceFunctionTenantKey).(string)
 	namespace := d.Get(resourceFunctionNamespaceKey).(string)
@@ -402,7 +401,7 @@ func resourcePulsarFunctionRead(ctx context.Context, d *schema.ResourceData, met
 }
 
 func resourcePulsarFunctionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(admin.Client).Functions()
+	client := getV3ClientFromMeta(meta).Functions()
 
 	functionConfig, err := marshalFunctionConfig(d)
 	if err != nil {
@@ -434,7 +433,7 @@ func resourcePulsarFunctionCreate(ctx context.Context, d *schema.ResourceData, m
 }
 
 func resourcePulsarFunctionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(admin.Client).Functions()
+	client := getV3ClientFromMeta(meta).Functions()
 
 	functionConfig, err := marshalFunctionConfig(d)
 	if err != nil {
@@ -465,7 +464,7 @@ func resourcePulsarFunctionUpdate(ctx context.Context, d *schema.ResourceData, m
 }
 
 func resourcePulsarFunctionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(admin.Client).Functions()
+	client := getV3ClientFromMeta(meta).Functions()
 
 	tenant := d.Get(resourceFunctionTenantKey).(string)
 	namespace := d.Get(resourceFunctionNamespaceKey).(string)

--- a/pulsar/resource_pulsar_function.go
+++ b/pulsar/resource_pulsar_function.go
@@ -395,7 +395,11 @@ func resourcePulsarFunctionRead(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(errors.Wrapf(err, "failed to get function %s", d.Id()))
 	}
 
-	unmarshalFunctionConfig(functionConfig, d)
+	err = unmarshalFunctionConfig(functionConfig, d)
+	if err != nil {
+		tflog.Debug(ctx, fmt.Sprintf("@@@Read function: %v", err))
+		return diag.Errorf("ERROR_UNMARSHAL_FUNCTION_CONFIG: %v", err)
+	}
 
 	return nil
 }
@@ -675,19 +679,31 @@ func marshalFunctionConfig(d *schema.ResourceData) (*utils.FunctionConfig, error
 
 func unmarshalFunctionConfig(functionConfig utils.FunctionConfig, d *schema.ResourceData) error {
 	if functionConfig.Jar != nil {
-		d.Set(resourceFunctionJarKey, *functionConfig.Jar)
+		err := d.Set(resourceFunctionJarKey, *functionConfig.Jar)
+		if err != nil {
+			return err
+		}
 	}
 
 	if functionConfig.Py != nil {
-		d.Set(resourceFunctionPyKey, *functionConfig.Py)
+		err := d.Set(resourceFunctionPyKey, *functionConfig.Py)
+		if err != nil {
+			return err
+		}
 	}
 
 	if functionConfig.Go != nil {
-		d.Set(resourceFunctionGoKey, *functionConfig.Go)
+		err := d.Set(resourceFunctionGoKey, *functionConfig.Go)
+		if err != nil {
+			return err
+		}
 	}
 
 	if functionConfig.ClassName != "" {
-		d.Set(resourceFunctionClassNameKey, functionConfig.ClassName)
+		err := d.Set(resourceFunctionClassNameKey, functionConfig.ClassName)
+		if err != nil {
+			return err
+		}
 	}
 
 	if len(functionConfig.Inputs) != 0 {
@@ -701,31 +717,52 @@ func unmarshalFunctionConfig(functionConfig utils.FunctionConfig, d *schema.Reso
 	}
 
 	if functionConfig.TopicsPattern != nil {
-		d.Set(resourceFunctionTopicsPatternKey, *functionConfig.TopicsPattern)
+		err := d.Set(resourceFunctionTopicsPatternKey, *functionConfig.TopicsPattern)
+		if err != nil {
+			return err
+		}
 	}
 
 	if functionConfig.Parallelism != 0 {
-		d.Set(resourceFunctionParallelismKey, functionConfig.Parallelism)
+		err := d.Set(resourceFunctionParallelismKey, functionConfig.Parallelism)
+		if err != nil {
+			return err
+		}
 	}
 
 	if functionConfig.Output != "" {
-		d.Set(resourceFunctionOutputKey, functionConfig.Output)
+		err := d.Set(resourceFunctionOutputKey, functionConfig.Output)
+		if err != nil {
+			return err
+		}
 	}
 
 	if functionConfig.Parallelism != 0 {
-		d.Set(resourceFunctionParallelismKey, functionConfig.Parallelism)
+		err := d.Set(resourceFunctionParallelismKey, functionConfig.Parallelism)
+		if err != nil {
+			return err
+		}
 	}
 
 	if functionConfig.ProcessingGuarantees != "" {
-		d.Set(resourceFunctionProcessingGuaranteesKey, functionConfig.ProcessingGuarantees)
+		err := d.Set(resourceFunctionProcessingGuaranteesKey, functionConfig.ProcessingGuarantees)
+		if err != nil {
+			return err
+		}
 	}
 
 	if functionConfig.SubName != "" {
-		d.Set(resourceFunctionSubscriptionNameKey, functionConfig.SubName)
+		err := d.Set(resourceFunctionSubscriptionNameKey, functionConfig.SubName)
+		if err != nil {
+			return err
+		}
 	}
 
 	if functionConfig.SubscriptionPosition != "" {
-		d.Set(resourceFunctionSubscriptionPositionKey, functionConfig.SubscriptionPosition)
+		err := d.Set(resourceFunctionSubscriptionPositionKey, functionConfig.SubscriptionPosition)
+		if err != nil {
+			return err
+		}
 	}
 
 	err := d.Set(resourceFunctionCleanupSubscriptionKey, functionConfig.CleanupSubscription)

--- a/pulsar/resource_pulsar_function_test.go
+++ b/pulsar/resource_pulsar_function_test.go
@@ -64,6 +64,7 @@ func TestFunction(t *testing.T) {
 					if config == nil {
 						return fmt.Errorf("failed to create %s function", rs.Primary.ID)
 					}
+					fmt.Printf("config: %v\n", config)
 
 					assert.Equal(t, "function-1", config.Name)
 					assert.Equal(t, "public", config.Tenant)

--- a/pulsar/resource_pulsar_function_test.go
+++ b/pulsar/resource_pulsar_function_test.go
@@ -20,7 +20,7 @@ package pulsar
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -36,7 +36,7 @@ func init() {
 }
 
 func TestFunction(t *testing.T) {
-	configBytes, err := ioutil.ReadFile("testdata/function/main.tf")
+	configBytes, err := os.ReadFile("testdata/function/main.tf")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +101,7 @@ func testPulsarFunctionDestroy(s *terraform.State) error {
 }
 
 func getPulsarFunctionByResourceID(id string) (*utils.FunctionConfig, error) {
-	client := getClientFromMeta(testAccProvider.Meta()).Functions()
+	client := getV3ClientFromMeta(testAccProvider.Meta()).Functions()
 
 	parts := strings.Split(id, "/")
 	if len(parts) != 3 {

--- a/pulsar/resource_pulsar_function_test.go
+++ b/pulsar/resource_pulsar_function_test.go
@@ -69,6 +69,7 @@ func TestFunction(t *testing.T) {
 					assert.Equal(t, "public", config.Tenant)
 					assert.Equal(t, "default", config.Namespace)
 					assert.Equal(t, ProcessingGuaranteesAtLeastOnce, config.ProcessingGuarantees)
+					assert.NotNil(t, config.TimeoutMs)
 					assert.Equal(t, int64(6666), *config.TimeoutMs)
 					assert.NotNil(t, config.Resources)
 

--- a/pulsar/resource_pulsar_function_test.go
+++ b/pulsar/resource_pulsar_function_test.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/rest"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -43,7 +42,7 @@ func TestFunction(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                  func() { testAccPreCheckWithAPIVersion(t, config.V3) },
+		PreCheck:                  func() { testAccPreCheck(t) },
 		ProviderFactories:         testAccProviderFactories,
 		PreventPostDestroyRefresh: false,
 		CheckDestroy:              testPulsarFunctionDestroy,

--- a/pulsar/resource_pulsar_sink.go
+++ b/pulsar/resource_pulsar_sink.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/rest"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -360,7 +359,7 @@ func resourcePulsarSink() *schema.Resource {
 }
 
 func resourcePulsarSinkCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(admin.Client).Sinks()
+	client := getV3ClientFromMeta(meta).Sinks()
 
 	sinkConfig, err := marshalSinkConfig(d)
 	if err != nil {
@@ -380,7 +379,7 @@ func resourcePulsarSinkCreate(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func resourcePulsarSinkRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(admin.Client).Sinks()
+	client := getV3ClientFromMeta(meta).Sinks()
 
 	tenant := d.Get(resourceSinkTenantKey).(string)
 	namespace := d.Get(resourceSinkNamespaceKey).(string)
@@ -599,7 +598,7 @@ func resourcePulsarSinkRead(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 func resourcePulsarSinkUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(admin.Client).Sinks()
+	client := getV3ClientFromMeta(meta).Sinks()
 
 	sinkConfig, err := marshalSinkConfig(d)
 	if err != nil {
@@ -620,7 +619,7 @@ func resourcePulsarSinkUpdate(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func resourcePulsarSinkDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(admin.Client).Sinks()
+	client := getV3ClientFromMeta(meta).Sinks()
 
 	tenant := d.Get(resourceSinkTenantKey).(string)
 	namespace := d.Get(resourceSinkNamespaceKey).(string)

--- a/pulsar/resource_pulsar_sink_test.go
+++ b/pulsar/resource_pulsar_sink_test.go
@@ -204,7 +204,6 @@ func testSampleSink(name string) string {
 	return fmt.Sprintf(`
 provider "pulsar" {
   web_service_url = "http://localhost:8080"
-  api_version = "3"
 }
 
 resource "pulsar_sink" "test" {

--- a/pulsar/resource_pulsar_sink_test.go
+++ b/pulsar/resource_pulsar_sink_test.go
@@ -50,7 +50,7 @@ func TestSink(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                  func() { testAccPreCheckWithAPIVersion(t, config.V3) },
+		PreCheck:                  func() { testAccPreCheck(t) },
 		ProviderFactories:         testAccProviderFactories,
 		PreventPostDestroyRefresh: false,
 		CheckDestroy:              testPulsarSinkDestroy,
@@ -64,7 +64,7 @@ func TestSink(t *testing.T) {
 						return fmt.Errorf("%s not be found", name)
 					}
 
-					client := getClientFromMeta(testAccProvider.Meta()).Sinks()
+					client := getV3ClientFromMeta(testAccProvider.Meta()).Sinks()
 
 					parts := strings.Split(rs.Primary.ID, "/")
 					if len(parts) != 3 {
@@ -246,7 +246,7 @@ func TestSinkUpdate(t *testing.T) {
 	configString = strings.ReplaceAll(configString, "sink-1", "update-sink-test-1")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                  func() { testAccPreCheckWithAPIVersion(t, config.V3) },
+		PreCheck:                  func() { testAccPreCheck(t) },
 		ProviderFactories:         testAccProviderFactories,
 		PreventPostDestroyRefresh: false,
 		CheckDestroy:              testPulsarSinkDestroy,
@@ -260,7 +260,7 @@ func TestSinkUpdate(t *testing.T) {
 						return fmt.Errorf("%s not be found", name)
 					}
 
-					client := getClientFromMeta(testAccProvider.Meta()).Sinks()
+					client := getV3ClientFromMeta(testAccProvider.Meta()).Sinks()
 
 					parts := strings.Split(rs.Primary.ID, "/")
 					if len(parts) != 3 {

--- a/pulsar/resource_pulsar_sink_test.go
+++ b/pulsar/resource_pulsar_sink_test.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/rest"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
@@ -84,7 +83,7 @@ func TestSink(t *testing.T) {
 }
 
 func testPulsarSinkDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(admin.Client).Sinks()
+	client := getV3ClientFromMeta(testAccProvider.Meta()).Sinks()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "pulsar_sink" {

--- a/pulsar/resource_pulsar_source.go
+++ b/pulsar/resource_pulsar_source.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/rest"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -305,7 +304,7 @@ func resourcePulsarSource() *schema.Resource {
 }
 
 func resourcePulsarSourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(admin.Client).Sources()
+	client := getV3ClientFromMeta(meta).Sources()
 
 	sourceConfig, err := marshalSourceConfig(d)
 	if err != nil {
@@ -327,7 +326,7 @@ func resourcePulsarSourceCreate(ctx context.Context, d *schema.ResourceData, met
 }
 
 func resourcePulsarSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(admin.Client).Sources()
+	client := getV3ClientFromMeta(meta).Sources()
 
 	tenant := d.Get(resourceSourceTenantKey).(string)
 	namespace := d.Get(resourceSourceNamespaceKey).(string)
@@ -527,7 +526,7 @@ func resourcePulsarSourceRead(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func resourcePulsarSourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(admin.Client).Sources()
+	client := getV3ClientFromMeta(meta).Sources()
 
 	sourceConfig, err := marshalSourceConfig(d)
 	if err != nil {
@@ -548,7 +547,7 @@ func resourcePulsarSourceUpdate(ctx context.Context, d *schema.ResourceData, met
 }
 
 func resourcePulsarSourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(admin.Client).Sources()
+	client := getV3ClientFromMeta(meta).Sources()
 
 	tenant := d.Get(resourceSourceTenantKey).(string)
 	namespace := d.Get(resourceSourceNamespaceKey).(string)

--- a/pulsar/resource_pulsar_source_test.go
+++ b/pulsar/resource_pulsar_source_test.go
@@ -20,7 +20,7 @@ package pulsar
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 
@@ -44,13 +44,13 @@ var testdataSourceArchive = "https://www.apache.org/dyn/mirrors/mirrors.cgi" +
 	"?action=download&filename=pulsar/pulsar-2.10.4/connectors/pulsar-io-file-2.10.4.nar"
 
 func TestSource(t *testing.T) {
-	configBytes, err := ioutil.ReadFile("testdata/source/main.tf")
+	configBytes, err := os.ReadFile("testdata/source/main.tf")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:                  func() { testAccPreCheckWithAPIVersion(t, config.V3) },
+		PreCheck:                  func() { testAccPreCheck(t) },
 		ProviderFactories:         testAccProviderFactories,
 		PreventPostDestroyRefresh: false,
 		CheckDestroy:              testPulsarSourceDestroy,
@@ -114,7 +114,7 @@ func testPulsarSourceDestroy(s *terraform.State) error {
 }
 
 func getPulsarSourceByResourceID(id string) (*utils.SourceConfig, error) {
-	client := getClientFromMeta(testAccProvider.Meta()).Sources()
+	client := getV3ClientFromMeta(testAccProvider.Meta()).Sources()
 
 	parts := strings.Split(id, "/")
 	if len(parts) != 3 {

--- a/pulsar/resource_pulsar_source_test.go
+++ b/pulsar/resource_pulsar_source_test.go
@@ -223,7 +223,6 @@ func testSampleSource(name string) string {
 	return fmt.Sprintf(`
 provider "pulsar" {
   web_service_url = "%s"
-  api_version = "3"
 }
 
 resource "pulsar_source" "test" {

--- a/pulsar/testdata/function/main.tf
+++ b/pulsar/testdata/function/main.tf
@@ -1,7 +1,6 @@
 
 provider "pulsar" {
   web_service_url = "http://localhost:8080"
-  api_version = "3"
 }
 
 resource "pulsar_function" "function-1" {

--- a/pulsar/testdata/sink/main.tf
+++ b/pulsar/testdata/sink/main.tf
@@ -17,7 +17,6 @@
 
 provider "pulsar" {
   web_service_url = "http://localhost:8080"
-  api_version = "3"
 }
 
 resource "pulsar_sink" "sink-1" {

--- a/pulsar/testdata/source/main.tf
+++ b/pulsar/testdata/source/main.tf
@@ -17,7 +17,6 @@
 
 provider "pulsar" {
   web_service_url = "http://localhost:8080"
-  api_version = "3"
 }
 
 resource "pulsar_source" "source-1" {


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

For functions and connectors user, they will need to set `api_version` to `v3` when managing pulsar functions and connectors. But once the api_version set to v3, there is no way to manage other pulsar resources like tenants, because those resources are using v2 apis. 
This PR forces the functions and connectors using v3 API, at the same time, it will fall-back to v2 if accessing other resources apis. To make the pulsar provider works for all admin apis at the same provider instance.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*

- *Added integration tests for end-to-end deployment with large payloads (10MB)*
- *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [ ] `no-need-doc`

  (Please explain why)

- [x] `doc`

  (If this PR contains doc changes)

