### PR TITLE
feat: import support for pulsar_permission_grant

### DIFF
--- a/docs/resources/permission_grant.md
+++ b/docs/resources/permission_grant.md
@@ -27,3 +27,15 @@ Manages role permissions on exactly one Pulsar namespace or topic. Do not manage
 
 - `id` (String) The ID of this resource.
 
+## Import
+
+The import ID uses the same format as the resource ID: `{namespace}/{role}` for namespace grants or `{topic}/{role}` for topic grants. The role is the segment after the last `/`, so roles containing `/` cannot be imported.
+
+```shell
+terraform import pulsar_permission_grant.example tenant/namespace/role1
+```
+
+```shell
+terraform import pulsar_permission_grant.example persistent://tenant/namespace/topic1/role1
+```
+

--- a/pulsar/resource_pulsar_permission_grant.go
+++ b/pulsar/resource_pulsar_permission_grant.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -76,6 +77,10 @@ func resourcePulsarPermissionGrant() *schema.Resource {
 		Description: "Manages role permissions on exactly one Pulsar namespace or topic. Do not manage the same " +
 			"role through this resource and a nested `permission_grant` block on `pulsar_namespace` or `pulsar_topic`.",
 
+		Importer: &schema.ResourceImporter{
+			StateContext: resourcePulsarPermissionGrantImport,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"namespace": {
 				Type:     schema.TypeString,
@@ -112,6 +117,74 @@ func resourcePulsarPermissionGrant() *schema.Resource {
 			},
 		},
 	}
+}
+
+// parsePermissionGrantImportID splits a permission grant import ID into its
+// namespace or topic part and role. The ID mirrors the resource ID assigned on
+// create: {namespace}/{role} (tenant/namespace/role) or {topic}/{role}
+// ({domain}://tenant/namespace/topic/role). Topic IDs are recognized by the
+// required domain scheme; everything else is treated as tenant/namespace.
+// The role is the segment after the final slash, so roles containing "/" are
+// not importable.
+func parsePermissionGrantImportID(id string) (namespace string, topic string, role string, err error) {
+	if id == "" {
+		return "", "", "", fmt.Errorf("empty import ID, expected {namespace}/{role} or {topic}/{role}")
+	}
+	idx := strings.LastIndex(id, "/")
+	if idx < 0 || idx == len(id)-1 {
+		return "", "", "", fmt.Errorf("invalid import ID %q, expected {namespace}/{role} or {topic}/{role}", id)
+	}
+	role = id[idx+1:]
+	target := id[:idx]
+	if strings.Contains(target, "://") {
+		topic = target
+	} else {
+		namespace = target
+	}
+	return namespace, topic, role, nil
+}
+
+func resourcePulsarPermissionGrantImport(ctx context.Context, d *schema.ResourceData,
+	meta interface{}) ([]*schema.ResourceData, error) {
+	importID := d.Id()
+
+	namespace, topic, role, err := parsePermissionGrantImportID(importID)
+	if err != nil {
+		return nil, fmt.Errorf("ERROR_PARSE_PERMISSION_GRANT_IMPORT_ID: %w", err)
+	}
+
+	// Set the fields Read consumes and normalize the ID to the canonical
+	// {namespace}/{role} or {topic}/{role} form assigned on create.
+	canonicalID := ""
+	if topic != "" {
+		topicName, parseErr := utils.GetTopicName(topic)
+		if parseErr != nil {
+			return nil, fmt.Errorf("ERROR_PARSE_TOPIC_NAME: %w", parseErr)
+		}
+		_ = d.Set("topic", topicName.String())
+		canonicalID = fmt.Sprintf("%s/%s", topicName.String(), role)
+	} else {
+		nsName, parseErr := utils.GetNamespaceName(namespace)
+		if parseErr != nil {
+			return nil, fmt.Errorf("ERROR_PARSE_NAMESPACE_NAME: %w", parseErr)
+		}
+		_ = d.Set("namespace", nsName.String())
+		canonicalID = fmt.Sprintf("%s/%s", nsName.String(), role)
+	}
+	_ = d.Set("role", role)
+	d.SetId(canonicalID)
+
+	diags := resourcePulsarPermissionGrantRead(ctx, d, meta)
+	if diags.HasError() {
+		if diags[0].Detail != "" {
+			return nil, fmt.Errorf("import %q: %s: %s", importID, diags[0].Summary, diags[0].Detail)
+		}
+		return nil, fmt.Errorf("import %q: %s", importID, diags[0].Summary)
+	}
+	if d.Id() == "" {
+		return nil, fmt.Errorf("ERROR_PERMISSION_GRANT_NOT_FOUND: %s", importID)
+	}
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourcePulsarPermissionGrantCreate(ctx context.Context, d *schema.ResourceData,

--- a/pulsar/resource_pulsar_permission_grant.go
+++ b/pulsar/resource_pulsar_permission_grant.go
@@ -123,9 +123,10 @@ func resourcePulsarPermissionGrant() *schema.Resource {
 // namespace or topic part and role. The ID mirrors the resource ID assigned on
 // create: {namespace}/{role} (tenant/namespace/role) or {topic}/{role}
 // ({domain}://tenant/namespace/topic/role). Topic IDs are recognized by the
-// required domain scheme; everything else is treated as tenant/namespace.
-// The role is the segment after the final slash, so roles containing "/" are
-// not importable.
+// required domain scheme; anything else must be a tenant/namespace pair,
+// so an ID without a domain scheme and without a tenant/namespace slash is
+// rejected here. The role is the segment after the final slash, so roles
+// containing "/" are not importable.
 func parsePermissionGrantImportID(id string) (namespace string, topic string, role string, err error) {
 	if id == "" {
 		return "", "", "", fmt.Errorf("empty import ID, expected {namespace}/{role} or {topic}/{role}")
@@ -136,10 +137,13 @@ func parsePermissionGrantImportID(id string) (namespace string, topic string, ro
 	}
 	role = id[idx+1:]
 	target := id[:idx]
-	if strings.Contains(target, "://") {
+	switch {
+	case strings.Contains(target, "://"):
 		topic = target
-	} else {
+	case strings.Contains(target, "/"):
 		namespace = target
+	default:
+		return "", "", "", fmt.Errorf("invalid import ID %q, expected {namespace}/{role} or {topic}/{role}", id)
 	}
 	return namespace, topic, role, nil
 }
@@ -174,14 +178,16 @@ func resourcePulsarPermissionGrantImport(ctx context.Context, d *schema.Resource
 	_ = d.Set("role", role)
 	d.SetId(canonicalID)
 
-	diags := resourcePulsarPermissionGrantRead(ctx, d, meta)
-	if diags.HasError() {
-		if diags[0].Detail != "" {
-			return nil, fmt.Errorf("import %q: %s: %s", importID, diags[0].Summary, diags[0].Detail)
+	client := getClientFromMeta(meta)
+
+	grants, err := fetchPermissionGrants(client, namespace, topic)
+	if err != nil {
+		if isIgnorableNotFoundError(err) {
+			return nil, fmt.Errorf("ERROR_PERMISSION_GRANT_NOT_FOUND: %s", importID)
 		}
-		return nil, fmt.Errorf("import %q: %s", importID, diags[0].Summary)
+		return nil, fmt.Errorf("import %q: %w", importID, err)
 	}
-	if d.Id() == "" {
+	if !applyPermissionGrantsToState(d, grants, role) {
 		return nil, fmt.Errorf("ERROR_PERMISSION_GRANT_NOT_FOUND: %s", importID)
 	}
 	return []*schema.ResourceData{d}, nil
@@ -263,45 +269,60 @@ func getTopicSpecificPermissions(client admin.Client, topicName *utils.TopicName
 	return map[string][]utils.AuthAction{}, nil
 }
 
-func resourcePulsarPermissionGrantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := getClientFromMeta(meta)
-	role := d.Get("role").(string)
-
-	var grants map[string][]utils.AuthAction
-	var err error
-
-	if namespace := d.Get("namespace").(string); namespace != "" {
-		nsName, parseErr := utils.GetNamespaceName(namespace)
-		if parseErr != nil {
-			return diag.FromErr(fmt.Errorf("ERROR_PARSE_NAMESPACE_NAME: %w", parseErr))
-		}
-
-		grants, err = client.Namespaces().GetNamespacePermissions(*nsName)
+// fetchPermissionGrants reads the raw role-to-actions grants map for a
+// namespace or topic. Errors are wrapped with the same prefixes the Read
+// path has always reported.
+func fetchPermissionGrants(client admin.Client, namespace string, topic string) (
+	map[string][]utils.AuthAction, error) {
+	if namespace != "" {
+		nsName, err := utils.GetNamespaceName(namespace)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("ERROR_READ_NAMESPACE_PERMISSION_GRANT: %w", err))
+			return nil, fmt.Errorf("ERROR_PARSE_NAMESPACE_NAME: %w", err)
 		}
-
-	} else if topic := d.Get("topic").(string); topic != "" {
-		topicName, parseErr := utils.GetTopicName(topic)
-		if parseErr != nil {
-			return diag.FromErr(fmt.Errorf("ERROR_PARSE_TOPIC_NAME: %w", parseErr))
-		}
-
-		grants, err = getTopicSpecificPermissions(client, topicName)
+		grants, err := client.Namespaces().GetNamespacePermissions(*nsName)
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("ERROR_READ_TOPIC_PERMISSION_GRANT: %w", err))
+			return nil, fmt.Errorf("ERROR_READ_NAMESPACE_PERMISSION_GRANT: %w", err)
 		}
+		return grants, nil
 	}
 
+	topicName, err := utils.GetTopicName(topic)
+	if err != nil {
+		return nil, fmt.Errorf("ERROR_PARSE_TOPIC_NAME: %w", err)
+	}
+	grants, err := getTopicSpecificPermissions(client, topicName)
+	if err != nil {
+		return nil, fmt.Errorf("ERROR_READ_TOPIC_PERMISSION_GRANT: %w", err)
+	}
+	return grants, nil
+}
+
+// applyPermissionGrantsToState stores the role's actions in state. It reports
+// whether the grant exists; a missing or empty grant clears the resource ID so
+// Terraform treats the resource as gone.
+func applyPermissionGrantsToState(d *schema.ResourceData, grants map[string][]utils.AuthAction, role string) bool {
 	if actions, exists := grants[role]; exists && len(actions) > 0 {
 		actionsSet := schema.NewSet(schema.HashString, []interface{}{})
 		for _, action := range actions {
 			actionsSet.Add(action.String())
 		}
 		_ = d.Set("actions", actionsSet)
-	} else {
-		d.SetId("")
+		return true
 	}
+	d.SetId("")
+	return false
+}
+
+func resourcePulsarPermissionGrantRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := getClientFromMeta(meta)
+	role := d.Get("role").(string)
+
+	grants, err := fetchPermissionGrants(client, d.Get("namespace").(string), d.Get("topic").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	applyPermissionGrantsToState(d, grants, role)
 
 	return nil
 }

--- a/pulsar/resource_pulsar_permission_grant_test.go
+++ b/pulsar/resource_pulsar_permission_grant_test.go
@@ -712,3 +712,118 @@ resource "pulsar_permission_grant" "test" {
 }
 `, wsURL, role)
 }
+
+func TestImportExistingPermissionGrantNamespace(t *testing.T) {
+	resourceName := "pulsar_permission_grant.test"
+	cName := acctest.RandString(10)
+	tName := acctest.RandString(10)
+	nsName := acctest.RandString(10)
+	roleName := acctest.RandString(10)
+	importID := fmt.Sprintf("%s/%s/%s", tName, nsName, roleName)
+
+	config := testPulsarPermissionGrantNamespace(testWebServiceURL, cName, tName, nsName, roleName,
+		`["produce", "consume"]`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testPulsarPermissionGrantDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testPulsarPermissionGrantExists(),
+				),
+			},
+			{
+				Config:            config,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     importID,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestImportExistingPermissionGrantTopic(t *testing.T) {
+	resourceName := "pulsar_permission_grant.test"
+	cName := acctest.RandString(10)
+	tName := acctest.RandString(10)
+	nsName := acctest.RandString(10)
+	topicName := acctest.RandString(10)
+	roleName := acctest.RandString(10)
+	importID := fmt.Sprintf("persistent://%s/%s/%s/%s", tName, nsName, topicName, roleName)
+
+	config := testPulsarPermissionGrantTopic(testWebServiceURL, cName, tName, nsName, topicName, roleName,
+		`["produce", "consume"]`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testPulsarPermissionGrantDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testPulsarPermissionGrantExists(),
+				),
+			},
+			{
+				Config:            config,
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     importID,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestImportNonExistingPermissionGrant(t *testing.T) {
+	cName := acctest.RandString(10)
+	tName := acctest.RandString(10)
+	nsName := acctest.RandString(10)
+	roleName := acctest.RandString(10)
+	nonExistingRole := "non-existing-role-" + acctest.RandString(10)
+	importID := fmt.Sprintf("%s/%s/%s", tName, nsName, nonExistingRole)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testPulsarPermissionGrantDestroy,
+		Steps: []resource.TestStep{
+			{
+				ResourceName:  "pulsar_permission_grant.test",
+				ImportState:   true,
+				Config:        testPulsarPermissionGrantNamespace(testWebServiceURL, cName, tName, nsName, roleName, `["produce"]`),
+				ImportStateId: importID,
+				ExpectError:   regexp.MustCompile("ERROR_PERMISSION_GRANT_NOT_FOUND"),
+			},
+		},
+	})
+}
+
+func TestImportExistingPermissionGrantWithIncorrectId(t *testing.T) {
+	cName := acctest.RandString(10)
+	tName := acctest.RandString(10)
+	nsName := acctest.RandString(10)
+	roleName := acctest.RandString(10)
+	// missing the role segment
+	incorrectID := fmt.Sprintf("%s/%s", tName, nsName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testPulsarPermissionGrantDestroy,
+		Steps: []resource.TestStep{
+			{
+				ResourceName:  "pulsar_permission_grant.test",
+				ImportState:   true,
+				Config:        testPulsarPermissionGrantNamespace(testWebServiceURL, cName, tName, nsName, roleName, `["produce"]`),
+				ImportStateId: incorrectID,
+				ExpectError:   regexp.MustCompile("ERROR_PARSE_PERMISSION_GRANT_IMPORT_ID"),
+			},
+		},
+	})
+}

--- a/pulsar/resource_pulsar_permission_grant_test.go
+++ b/pulsar/resource_pulsar_permission_grant_test.go
@@ -794,9 +794,38 @@ func TestImportNonExistingPermissionGrant(t *testing.T) {
 		CheckDestroy:      testPulsarPermissionGrantDestroy,
 		Steps: []resource.TestStep{
 			{
+				// Create the namespace first: import steps never apply Config,
+				// the SDK only sets it as the import working directory.
+				Config: testPulsarPermissionGrantNamespace(testWebServiceURL, cName, tName, nsName, roleName, `["produce"]`),
+			},
+			{
 				ResourceName:  "pulsar_permission_grant.test",
 				ImportState:   true,
-				Config:        testPulsarPermissionGrantNamespace(testWebServiceURL, cName, tName, nsName, roleName, `["produce"]`),
+				ImportStateId: importID,
+				ExpectError:   regexp.MustCompile("ERROR_PERMISSION_GRANT_NOT_FOUND"),
+			},
+		},
+	})
+}
+
+// TestImportNonExistingNamespacePermissionGrant imports a grant whose
+// namespace does not exist. The 404 from the permissions read must be
+// classified as ERROR_PERMISSION_GRANT_NOT_FOUND instead of a raw read error.
+func TestImportNonExistingNamespacePermissionGrant(t *testing.T) {
+	tName := acctest.RandString(10)
+	nsName := acctest.RandString(10)
+	roleName := acctest.RandString(10)
+	importID := fmt.Sprintf("%s/%s/%s", tName, nsName, roleName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testPulsarPermissionGrantDestroy,
+		Steps: []resource.TestStep{
+			{
+				ResourceName:  "pulsar_permission_grant.test",
+				ImportState:   true,
+				Config:        testPulsarPermissionGrantNamespace(testWebServiceURL, acctest.RandString(10), tName, nsName, roleName, `["produce"]`),
 				ImportStateId: importID,
 				ExpectError:   regexp.MustCompile("ERROR_PERMISSION_GRANT_NOT_FOUND"),
 			},

--- a/pulsar/resource_pulsar_permission_grant_test.go
+++ b/pulsar/resource_pulsar_permission_grant_test.go
@@ -823,9 +823,10 @@ func TestImportNonExistingNamespacePermissionGrant(t *testing.T) {
 		CheckDestroy:      testPulsarPermissionGrantDestroy,
 		Steps: []resource.TestStep{
 			{
-				ResourceName:  "pulsar_permission_grant.test",
-				ImportState:   true,
-				Config:        testPulsarPermissionGrantNamespace(testWebServiceURL, acctest.RandString(10), tName, nsName, roleName, `["produce"]`),
+				ResourceName: "pulsar_permission_grant.test",
+				ImportState:  true,
+				Config: testPulsarPermissionGrantNamespace(
+					testWebServiceURL, acctest.RandString(10), tName, nsName, roleName, `["produce"]`),
 				ImportStateId: importID,
 				ExpectError:   regexp.MustCompile("ERROR_PERMISSION_GRANT_NOT_FOUND"),
 			},

--- a/pulsar/resource_pulsar_permission_grant_unit_test.go
+++ b/pulsar/resource_pulsar_permission_grant_unit_test.go
@@ -219,12 +219,14 @@ func TestParsePermissionGrantImportID(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "namespace only id",
-			id:   "tenant/ns",
-			// parses as namespace "tenant" with role "ns"; the importer
-			// rejects it later in GetNamespaceName
-			namespace: "tenant",
-			role:      "ns",
+			name:    "namespace only id (missing role)",
+			id:      "tenant/ns",
+			wantErr: true,
+		},
+		{
+			name:    "tenant only id",
+			id:      "tenant",
+			wantErr: true,
 		},
 		{
 			name:    "trailing slash",

--- a/pulsar/resource_pulsar_permission_grant_unit_test.go
+++ b/pulsar/resource_pulsar_permission_grant_unit_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/rest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -183,4 +184,85 @@ func TestRetryOnConflict_ContextCanceledStopsRetry(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
 	assert.Less(t, calls, 10, "retry loop must stop soon after context cancellation")
+}
+
+func TestParsePermissionGrantImportID(t *testing.T) {
+	tests := []struct {
+		name      string
+		id        string
+		namespace string
+		topic     string
+		role      string
+		wantErr   bool
+	}{
+		{
+			name:      "namespace id",
+			id:        "tenant/ns/role1",
+			namespace: "tenant/ns",
+			role:      "role1",
+		},
+		{
+			name:  "persistent topic id",
+			id:    "persistent://tenant/ns/topic1/role1",
+			topic: "persistent://tenant/ns/topic1",
+			role:  "role1",
+		},
+		{
+			name:  "non-persistent topic id",
+			id:    "non-persistent://tenant/ns/topic1/role1",
+			topic: "non-persistent://tenant/ns/topic1",
+			role:  "role1",
+		},
+		{
+			name:    "empty id",
+			id:      "",
+			wantErr: true,
+		},
+		{
+			name: "namespace only id",
+			id:   "tenant/ns",
+			// parses as namespace "tenant" with role "ns"; the importer
+			// rejects it later in GetNamespaceName
+			namespace: "tenant",
+			role:      "ns",
+		},
+		{
+			name:    "trailing slash",
+			id:      "tenant/ns/",
+			wantErr: true,
+		},
+		{
+			name: "topic missing role",
+			id:   "persistent://tenant/ns/topic1",
+			// parses as topic "persistent://tenant/ns" with role "topic1";
+			// GetTopicName rejects it later in the importer
+			topic: "persistent://tenant/ns",
+			role:  "topic1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns, topic, role, err := parsePermissionGrantImportID(tt.id)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.namespace, ns)
+			assert.Equal(t, tt.topic, topic)
+			assert.Equal(t, tt.role, role)
+		})
+	}
+}
+
+// TestResourcePulsarPermissionGrantImport_InvalidId verifies the importer
+// rejects malformed IDs before any API call.
+func TestResourcePulsarPermissionGrantImport_InvalidId(t *testing.T) {
+	d := schema.TestResourceDataRaw(t, resourcePulsarPermissionGrant().Schema, map[string]interface{}{})
+	d.SetId("no-slash-here")
+
+	_, err := resourcePulsarPermissionGrantImport(context.Background(), d, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ERROR_PARSE_PERMISSION_GRANT_IMPORT_ID")
 }


### PR DESCRIPTION
Add terraform import via custom Importer StateContext. Import ID mirrors the resource ID assigned on create: {namespace}/{role} or {topic}/{role}. Topic IDs are detected by the domain scheme (://), the role is the segment after the last slash. The importer sets namespace/topic/role, normalizes the ID to the canonical create form, then delegates to Read; a role with no grants maps to ERROR_PERMISSION_GRANT_NOT_FOUND.

Includes parse unit tests, acceptance tests for namespace/topic import, not-found and malformed-ID paths, and docs import section.

<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*

- *Added integration tests for end-to-end deployment with large payloads (10MB)*
- *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs?

- [ ] `doc-required`

  (If you need help on updating docs, create a doc issue)

- [ ] `no-need-doc`

  (Please explain why)

- [ ] `doc`

  (If this PR contains doc changes)

