### PR TITLE
Add namespace bundle count support

### DIFF
--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -21,6 +21,7 @@ Manages Pulsar namespaces and namespace-level policies.
 ### Optional
 
 - `backlog_quota` (Block Set) Manages configured backlog quota types. During `terraform import`, broker values are recorded without claiming ownership. Terraform leaves unowned types unchanged and removes only types it previously applied. (see [below for nested schema](#nestedblock--backlog_quota))
+- `bundles` (Number) Number of namespace bundles. If omitted, Pulsar uses the broker default. Changing this value recreates the namespace.
 - `dispatch_rate` (Block Set, Max: 1) Data transfer rate for all the topics under the given namespace. During `terraform import`, the provider records the broker policy. Omitting the block preserves that policy; configure the block to update it. (see [below for nested schema](#nestedblock--dispatch_rate))
 - `enable_deduplication` (Boolean)
 - `inactive_topic` (Block Set, Max: 1) (see [below for nested schema](#nestedblock--inactive_topic))

--- a/pkg/admin/namespace_policy.go
+++ b/pkg/admin/namespace_policy.go
@@ -32,6 +32,7 @@ import (
 // NamespacePolicyClient provides namespace policy operations missing from the
 // pulsaradmin version currently used by the provider.
 type NamespacePolicyClient interface {
+	GetNamespaceBundles(context.Context, string) (*utils.BundlesData, error)
 	RemoveBacklogQuotaByType(context.Context, string, utils.BacklogQuotaType) error
 }
 
@@ -63,6 +64,27 @@ func NewNamespacePolicyClient(c *PulsarAdminConfig) (NamespacePolicyClient, erro
 		},
 		apiVersion: c.Config.PulsarAPIVersion,
 	}, nil
+}
+
+func (c *namespacePolicyClient) GetNamespaceBundles(
+	ctx context.Context,
+	namespace string,
+) (*utils.BundlesData, error) {
+	ns, err := utils.GetNamespaceName(namespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid namespace")
+	}
+
+	endpoint := path.Join(
+		utils.MakeHTTPPath(c.apiVersion.String(), "/namespaces"),
+		ns.String(),
+		"bundles",
+	)
+	bundles := new(utils.BundlesData)
+	if err := c.client.GetWithContext(ctx, endpoint, bundles); err != nil {
+		return nil, err
+	}
+	return bundles, nil
 }
 
 func (c *namespacePolicyClient) RemoveBacklogQuotaByType(

--- a/pkg/admin/namespace_policy_test.go
+++ b/pkg/admin/namespace_policy_test.go
@@ -67,3 +67,30 @@ func TestNamespacePolicyClientRemoveBacklogQuotaByType(t *testing.T) {
 		})
 	}
 }
+
+func TestNamespacePolicyClientGetNamespaceBundles(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/admin/v2/namespaces/public/default/bundles", r.URL.Path)
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+		_, err := w.Write([]byte(`{
+			"boundaries":["0x00000000","0x40000000","0x80000000","0xc0000000","0xffffffff"],
+			"numBundles":4
+		}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client, err := NewNamespacePolicyClient(&PulsarAdminConfig{Config: &adminconfig.Config{
+		WebServiceURL: server.URL,
+		Token:         "test-token",
+	}})
+	require.NoError(t, err)
+
+	bundles, err := client.GetNamespaceBundles(context.Background(), "public/default")
+	require.NoError(t, err)
+	require.Equal(t, 4, bundles.NumBundles)
+	require.Len(t, bundles.Boundaries, 5)
+}

--- a/pulsar/resource_pulsar_namespace.go
+++ b/pulsar/resource_pulsar_namespace.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -33,6 +34,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/streamnative/terraform-provider-pulsar/hashcode"
 	"github.com/streamnative/terraform-provider-pulsar/types"
@@ -72,7 +74,7 @@ func resourcePulsarNamespace() *schema.Resource {
 			},
 		},
 		Importer: &schema.ResourceImporter{
-			StateContext: func(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+			StateContext: func(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 				importID := d.Id()
 				ns, err := utils.GetNamespaceName(importID)
 				if err != nil {
@@ -82,7 +84,7 @@ func resourcePulsarNamespace() *schema.Resource {
 				_ = d.Set("tenant", nsParts[0])
 				_ = d.Set("namespace", nsParts[1])
 
-				diags := resourcePulsarNamespaceReadWithMode(d, meta, namespaceReadImport)
+				diags := resourcePulsarNamespaceReadWithMode(ctx, d, meta, namespaceReadImport)
 				if diags.HasError() {
 					return nil, fmt.Errorf("import %q: %s", importID, diags[0].Summary)
 				}
@@ -111,6 +113,15 @@ func resourcePulsarNamespace() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: descriptions["tenant"],
+			},
+			"bundles": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IntBetween(1, math.MaxInt32),
+				Description: "Number of namespace bundles. If omitted, Pulsar uses the broker default. " +
+					"Changing this value recreates the namespace.",
 			},
 			"enable_deduplication": {
 				Type:     schema.TypeBool,
@@ -558,8 +569,16 @@ func resourcePulsarNamespaceCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.FromErr(fmt.Errorf("ERROR_PARSE_NAMESPACE_NAME: %w", err))
 	}
 
-	if err := client.CreateNamespace(ns.String()); err != nil {
-		return diag.FromErr(fmt.Errorf("ERROR_CREATE_NAMESPACE: %w", err))
+	var createErr error
+	if bundles, ok := d.GetOk("bundles"); ok {
+		policies := utils.NewDefaultPolicies()
+		policies.Bundles = utils.NewBundlesDataWithNumBundles(bundles.(int))
+		createErr = client.CreateNsWithPolicesWithContext(ctx, ns.String(), *policies)
+	} else {
+		createErr = client.CreateNamespaceWithContext(ctx, ns.String())
+	}
+	if createErr != nil {
+		return diag.FromErr(fmt.Errorf("ERROR_CREATE_NAMESPACE: %w", createErr))
 	}
 
 	if err := resourcePulsarNamespaceUpdate(ctx, d, meta); err != nil {
@@ -569,8 +588,8 @@ func resourcePulsarNamespaceCreate(ctx context.Context, d *schema.ResourceData, 
 	return nil
 }
 
-func resourcePulsarNamespaceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return resourcePulsarNamespaceReadWithMode(d, meta, namespaceReadRefresh)
+func resourcePulsarNamespaceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourcePulsarNamespaceReadWithMode(ctx, d, meta, namespaceReadRefresh)
 }
 
 // resourcePulsarNamespaceReadWithMode refreshes a namespace into state. Import mode force-hydrates
@@ -578,6 +597,7 @@ func resourcePulsarNamespaceRead(_ context.Context, d *schema.ResourceData, meta
 // only reads blocks already tracked in state/config, preserving the v0.11 least-privilege behavior
 // for namespaces that do not manage these policies.
 func resourcePulsarNamespaceReadWithMode(
+	ctx context.Context,
 	d *schema.ResourceData,
 	meta interface{},
 	mode namespaceReadMode,
@@ -603,6 +623,17 @@ func resourcePulsarNamespaceReadWithMode(
 
 	_ = d.Set("namespace", namespace)
 	_ = d.Set("tenant", tenant)
+	bundleData, err := getNamespacePolicyClientFromMeta(meta).GetNamespaceBundles(ctx, ns.String())
+	if err != nil {
+		if isAdminNotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(fmt.Errorf("ERROR_READ_NAMESPACE: GetNamespaceBundles: %w", err))
+	}
+	if err := d.Set("bundles", bundleData.NumBundles); err != nil {
+		return diag.FromErr(fmt.Errorf("ERROR_READ_NAMESPACE: SetNamespaceBundlesState: %w", err))
+	}
 	if d.GetRawConfig().IsNull() {
 		if err := initializeBacklogQuotaManagedTypesState(d); err != nil {
 			return diag.FromErr(fmt.Errorf("ERROR_READ_NAMESPACE: SetBacklogQuotaOwnershipState: %w", err))
@@ -1637,6 +1668,7 @@ func resourcePulsarNamespaceDelete(ctx context.Context, d *schema.ResourceData, 
 
 	_ = d.Set("namespace", "")
 	_ = d.Set("tenant", "")
+	_ = d.Set("bundles", nil)
 	_ = d.Set("enable_deduplication", nil)
 	_ = d.Set("namespace_config", nil)
 	_ = d.Set("retention_policies", nil)

--- a/pulsar/resource_pulsar_namespace_policy_test.go
+++ b/pulsar/resource_pulsar_namespace_policy_test.go
@@ -36,13 +36,20 @@ import (
 	provideradmin "github.com/streamnative/terraform-provider-pulsar/pkg/admin"
 )
 
-func TestResourcePulsarNamespaceRead_MinimalRefreshSkipsPolicyReads(t *testing.T) {
+func TestResourcePulsarNamespaceRead_MinimalRefreshOnlyReadsBundles(t *testing.T) {
 	t.Parallel()
 
 	var policyReads int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/admin/v2/namespaces/tenant" {
 			writeJSONResponse(t, w, http.StatusOK, []string{"tenant/namespace"})
+			return
+		}
+		if r.URL.Path == "/admin/v2/namespaces/tenant/namespace/bundles" {
+			writeJSONResponse(t, w, http.StatusOK, map[string]interface{}{
+				"boundaries": []string{"0x00000000", "0xffffffff"},
+				"numBundles": 1,
+			})
 			return
 		}
 		policyReads++
@@ -52,10 +59,67 @@ func TestResourcePulsarNamespaceRead_MinimalRefreshSkipsPolicyReads(t *testing.T
 
 	d := namespacePolicyTestResourceData(t, nil)
 	diags := resourcePulsarNamespaceReadWithMode(
-		d, namespacePolicyTestClientBundle(t, server.URL), namespaceReadRefresh,
+		context.Background(), d, namespacePolicyTestClientBundle(t, server.URL), namespaceReadRefresh,
 	)
 	require.False(t, diags.HasError(), "unexpected diagnostics: %#v", diags)
 	require.Zero(t, policyReads)
+}
+
+func TestResourcePulsarNamespaceCreate_Bundles(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name            string
+		configured      interface{}
+		brokerBundles   int
+		wantRequestBody bool
+	}{
+		{name: "broker default", brokerBundles: 4},
+		{name: "explicit count", configured: 3, brokerBundles: 3, wantRequestBody: true},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodPut && r.URL.Path == "/admin/v2/namespaces/tenant/namespace":
+					if test.wantRequestBody {
+						var policies utils.Policies
+						require.NoError(t, json.NewDecoder(r.Body).Decode(&policies))
+						require.NotNil(t, policies.Bundles)
+						require.Equal(t, test.brokerBundles, policies.Bundles.NumBundles)
+						require.NotNil(t, policies.ReplicationClusters)
+					} else {
+						require.Zero(t, r.ContentLength)
+					}
+					w.WriteHeader(http.StatusNoContent)
+				case r.Method == http.MethodGet && r.URL.Path == "/admin/v2/namespaces/tenant":
+					writeJSONResponse(t, w, http.StatusOK, []string{"tenant/namespace"})
+				case r.Method == http.MethodGet && r.URL.Path == "/admin/v2/namespaces/tenant/namespace/bundles":
+					writeJSONResponse(t, w, http.StatusOK, map[string]interface{}{"numBundles": test.brokerBundles})
+				default:
+					writeJSONResponse(t, w, http.StatusNotFound, map[string]string{"reason": "unexpected request"})
+				}
+			}))
+			defer server.Close()
+
+			config := map[string]interface{}{
+				"tenant":    "tenant",
+				"namespace": "namespace",
+			}
+			if test.configured != nil {
+				config["bundles"] = test.configured
+			}
+			d := schema.TestResourceDataRaw(t, resourcePulsarNamespace().Schema, config)
+			diags := resourcePulsarNamespaceCreate(
+				context.Background(), d, namespacePolicyTestClientBundle(t, server.URL),
+			)
+			require.False(t, diags.HasError(), "unexpected diagnostics: %#v", diags)
+			require.Equal(t, "tenant/namespace", d.Id())
+			require.Equal(t, test.brokerBundles, d.Get("bundles"))
+		})
+	}
 }
 
 func TestResourcePulsarNamespaceRead_ImportRequiresPolicyReads(t *testing.T) {
@@ -67,6 +131,10 @@ func TestResourcePulsarNamespaceRead_ImportRequiresPolicyReads(t *testing.T) {
 			writeJSONResponse(t, w, http.StatusOK, []string{"tenant/namespace"})
 			return
 		}
+		if r.URL.Path == "/admin/v2/namespaces/tenant/namespace/bundles" {
+			writeJSONResponse(t, w, http.StatusOK, map[string]interface{}{"numBundles": 4})
+			return
+		}
 		policyReads++
 		writeJSONResponse(t, w, http.StatusForbidden, map[string]string{"reason": "policy read forbidden"})
 	}))
@@ -74,7 +142,7 @@ func TestResourcePulsarNamespaceRead_ImportRequiresPolicyReads(t *testing.T) {
 
 	d := namespacePolicyTestResourceData(t, nil)
 	diags := resourcePulsarNamespaceReadWithMode(
-		d, namespacePolicyTestClientBundle(t, server.URL), namespaceReadImport,
+		context.Background(), d, namespacePolicyTestClientBundle(t, server.URL), namespaceReadImport,
 	)
 	require.True(t, diags.HasError())
 	require.Equal(t, 1, policyReads)
@@ -101,13 +169,17 @@ func TestResourcePulsarNamespaceRead_UnsetPoliciesClearTrackedState(t *testing.T
 					writeJSONResponse(t, w, http.StatusOK, []string{"tenant/namespace"})
 					return
 				}
+				if r.URL.Path == "/admin/v2/namespaces/tenant/namespace/bundles" {
+					writeJSONResponse(t, w, http.StatusOK, map[string]interface{}{"numBundles": 4})
+					return
+				}
 				writeJSONResponse(t, w, response.status, response.body)
 			}))
 			defer server.Close()
 
 			d := namespacePolicyTestResourceData(t, namespacePolicyTestBlocks())
 			diags := resourcePulsarNamespaceReadWithMode(
-				d, namespacePolicyTestClientBundle(t, server.URL), namespaceReadRefresh,
+				context.Background(), d, namespacePolicyTestClientBundle(t, server.URL), namespaceReadRefresh,
 			)
 			require.False(t, diags.HasError(), "unexpected diagnostics: %#v", diags)
 			require.Zero(t, d.Get("dispatch_rate").(*schema.Set).Len())
@@ -134,7 +206,7 @@ func TestResourcePulsarNamespaceRead_PolicyNotFoundMarksResourceMissing(t *testi
 		"persistence_policies": namespacePolicyTestBlocks()["persistence_policies"],
 	})
 	diags := resourcePulsarNamespaceReadWithMode(
-		d, namespacePolicyTestClientBundle(t, server.URL), namespaceReadRefresh,
+		context.Background(), d, namespacePolicyTestClientBundle(t, server.URL), namespaceReadRefresh,
 	)
 	require.False(t, diags.HasError(), "unexpected diagnostics: %#v", diags)
 	require.Empty(t, d.Id())
@@ -413,6 +485,8 @@ func namespacePolicyConfiguredHandler(
 		switch r.URL.Path {
 		case "/admin/v2/namespaces/tenant":
 			writeJSONResponse(t, w, http.StatusOK, []string{"tenant/namespace"})
+		case "/admin/v2/namespaces/tenant/namespace/bundles":
+			writeJSONResponse(t, w, http.StatusOK, map[string]interface{}{"numBundles": 4})
 		case "/admin/v2/namespaces/tenant/namespace/persistence":
 			writeJSONResponse(t, w, http.StatusOK, map[string]interface{}{
 				"bookkeeperEnsemble":             2,

--- a/pulsar/resource_pulsar_namespace_schema_test.go
+++ b/pulsar/resource_pulsar_namespace_schema_test.go
@@ -19,6 +19,7 @@ package pulsar
 
 import (
 	"context"
+	"math"
 	"strconv"
 	"testing"
 
@@ -27,6 +28,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPulsarNamespaceBundlesSchema(t *testing.T) {
+	t.Parallel()
+
+	bundles := resourcePulsarNamespace().Schema["bundles"]
+	require.Equal(t, schema.TypeInt, bundles.Type)
+	require.True(t, bundles.Optional)
+	require.True(t, bundles.Computed)
+	require.True(t, bundles.ForceNew)
+	require.False(t, bundles.Required)
+
+	for _, valid := range []int{1, 3, 32, math.MaxInt32} {
+		_, errs := bundles.ValidateFunc(valid, "bundles")
+		require.Empty(t, errs, "bundles=%d should be valid", valid)
+	}
+	for _, invalid := range []int{-1, 0, math.MaxInt32 + 1} {
+		_, errs := bundles.ValidateFunc(invalid, "bundles")
+		require.NotEmpty(t, errs, "bundles=%d should be invalid", invalid)
+	}
+}
 
 func TestPulsarNamespaceStateUpgradeV0(t *testing.T) {
 	t.Parallel()

--- a/pulsar/resource_pulsar_namespace_test.go
+++ b/pulsar/resource_pulsar_namespace_test.go
@@ -88,12 +88,45 @@ func TestNamespace(t *testing.T) {
 				Config: testPulsarNamespace(testWebServiceURL, cName, tName, nsName),
 				Check: resource.ComposeTestCheckFunc(
 					testPulsarNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bundles", "1"),
 				),
 			},
 			{
 				Config:             testPulsarNamespace(testWebServiceURL, cName, tName, nsName),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestNamespaceBundles(t *testing.T) {
+	resourceName := "pulsar_namespace.test"
+	cName := acctest.RandString(10)
+	tName := acctest.RandString(10)
+	nsName := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		IDRefreshName:     resourceName,
+		CheckDestroy:      testPulsarNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testPulsarNamespaceBundles(testWebServiceURL, cName, tName, nsName, 3),
+				Check: resource.ComposeTestCheckFunc(
+					testPulsarNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bundles", "3"),
+					testNamespaceBundleCount(tName+"/"+nsName, 3),
+				),
+			},
+			{
+				Config: testPulsarNamespaceBundles(testWebServiceURL, cName, tName, nsName, 6),
+				Check: resource.ComposeTestCheckFunc(
+					testPulsarNamespaceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "bundles", "6"),
+					testNamespaceBundleCount(tName+"/"+nsName, 6),
+				),
 			},
 		},
 	})
@@ -693,6 +726,27 @@ func testPulsarNamespaceExists(ns string) resource.TestCheckFunc {
 	}
 }
 
+func testNamespaceBundleCount(namespace string, want int) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		policies, err := getClientFromMeta(testAccProvider.Meta()).Namespaces().GetPolicies(namespace)
+		if err != nil {
+			return fmt.Errorf("get namespace bundle count: %w", err)
+		}
+		if policies.Bundles == nil {
+			return fmt.Errorf("namespace %q has no bundle data", namespace)
+		}
+		if policies.Bundles.NumBundles != want {
+			return fmt.Errorf(
+				"namespace %q bundle count is %d, want %d",
+				namespace,
+				policies.Bundles.NumBundles,
+				want,
+			)
+		}
+		return nil
+	}
+}
+
 func testNamespaceImported() resource.ImportStateCheckFunc {
 	return func(s []*terraform.InstanceState) error {
 		if len(s) != 1 {
@@ -700,8 +754,8 @@ func testNamespaceImported() resource.ImportStateCheckFunc {
 		}
 
 		attrs := s[0].Attributes
-		if len(attrs) != 14 {
-			return fmt.Errorf("expected %d attrs, got %d: %#v", 14, len(attrs), attrs)
+		if len(attrs) != 15 {
+			return fmt.Errorf("expected %d attrs, got %d: %#v", 15, len(attrs), attrs)
 		}
 
 		if got := attrs[backlogQuotaManagedTypesStateAttr+".#"]; got != "0" {
@@ -770,6 +824,35 @@ resource "pulsar_namespace" "test" {
   namespace = "%s"
 }
 `, wsURL, cluster, tenant, ns)
+}
+
+func testPulsarNamespaceBundles(wsURL, cluster, tenant, namespace string, bundles int) string {
+	return fmt.Sprintf(`
+provider "pulsar" {
+  web_service_url = "%s"
+}
+
+resource "pulsar_cluster" "test_cluster" {
+  cluster = "%s"
+
+  cluster_data {
+    web_service_url    = "http://localhost:8080"
+    broker_service_url = "pulsar://localhost:6050"
+    peer_clusters      = ["standalone"]
+  }
+}
+
+resource "pulsar_tenant" "test_tenant" {
+  tenant           = "%s"
+  allowed_clusters = [pulsar_cluster.test_cluster.cluster, "standalone"]
+}
+
+resource "pulsar_namespace" "test" {
+  tenant    = pulsar_tenant.test_tenant.tenant
+  namespace = "%s"
+  bundles   = %d
+}
+`, wsURL, cluster, tenant, namespace, bundles)
 }
 
 func testPulsarNamespace(wsURL, cluster, tenant, ns string) string {


### PR DESCRIPTION
## Summary

- add an optional, computed, ForceNew `bundles` attribute to `pulsar_namespace`
- use the broker default when omitted and hydrate the actual count during refresh and import
- create namespaces with initialized policies so Pulsar 4.0.3 receives non-null replication cluster data
- validate the positive Java `int` range while preserving valid non-power-of-two counts

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `golangci-lint v2.4.0 run -c .golangci.yaml ./...`
- `tfproviderlint` with the repository lint flags
- Pulsar 4.0.3 acceptance: omitted broker default, explicit 3 bundles, ForceNew replacement from 3 to 6, and import/empty-plan coverage
- `go generate ./...` and `git diff --check`

Fixes #231.